### PR TITLE
fix: update Claude CLI flags and prioritize native installs over npm

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1752,7 +1752,12 @@ fn get_expanded_path() -> String {
 
     let mut expanded = Vec::new();
 
-    // For nvm/fnm, scan for node version dirs containing a bin/ folder
+    // Prefer well-known static locations (e.g. ~/.local/bin for native CLI installs)
+    for dir in static_dirs {
+        expanded.push(dir);
+    }
+
+    // Then scan nvm/fnm node version dirs containing a bin/ folder
     for base in &candidate_dirs {
         if let Ok(entries) = std::fs::read_dir(base) {
             for entry in entries.flatten() {
@@ -1762,10 +1767,6 @@ fn get_expanded_path() -> String {
                 }
             }
         }
-    }
-
-    for dir in static_dirs {
-        expanded.push(dir);
     }
 
     expanded.push(system_path);
@@ -1825,7 +1826,7 @@ async fn ai_execute_claude(
         });
     }
 
-    // Execute: echo "prompt" | claude <file> --permission-mode bypassPermissions --print
+    // Execute: echo "prompt" | claude <file> --dangerously-skip-permissions --print
     let timeout_duration = std::time::Duration::from_secs(300); // 5 minute timeout
     let shared_child: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));
     let child_for_task = Arc::clone(&shared_child);
@@ -1833,8 +1834,7 @@ async fn ai_execute_claude(
         let child = Command::new("claude")
             .env("PATH", &path)
             .arg(&file_path)
-            .arg("--permission-mode")
-            .arg("bypassPermissions")
+            .arg("--dangerously-skip-permissions")
             .arg("--print")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())


### PR DESCRIPTION
- Update deprecated --permission-mode bypassPermissions flag to               
  --dangerously-skip-permissions for compatibility with current Claude Code CLI 
  versions                                                                      
- Reorder PATH resolution in get_expanded_path() to prioritize static         
  directories (~/.local/bin, /usr/local/bin, /opt/homebrew/bin) over nvm/fnm    
  node version directories, preventing stale npm-installed CLI versions from    
  shadowing native installs    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted PATH resolution order for improved executable precedence handling, now prioritizing static directories before system PATH.
  * Updated Claude CLI invocation to use the latest permission flag syntax for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->