### PR TITLE
Fix open folder to navigate into directory and add to command palette

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1722,41 +1722,33 @@ async fn open_folder_dialog(
 }
 
 #[tauri::command]
-async fn reveal_in_file_manager(path: String) -> Result<(), String> {
+async fn open_in_file_manager(path: String) -> Result<(), String> {
     let path_buf = PathBuf::from(&path);
-    if !path_buf.exists() {
-        return Err("Path does not exist".to_string());
+    if !path_buf.exists() || !path_buf.is_dir() {
+        return Err("Path does not exist or is not a directory".to_string());
     }
 
     #[cfg(target_os = "macos")]
     {
         std::process::Command::new("open")
-            .args(["-R", &path])
+            .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
 
     #[cfg(target_os = "windows")]
     {
-        // Windows explorer /select requires backslashes
         let windows_path = path.replace("/", "\\");
         std::process::Command::new("explorer")
-            .args(["/select,", &windows_path])
+            .arg(&windows_path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
 
     #[cfg(target_os = "linux")]
     {
-        // Linux: open containing directory (most file managers don't support selecting)
-        let parent = path_buf
-            .parent()
-            .ok_or_else(|| "Cannot determine parent directory".to_string())?;
-        let parent_str = parent
-            .to_str()
-            .ok_or_else(|| "Path contains invalid UTF-8".to_string())?;
         std::process::Command::new("xdg-open")
-            .arg(parent_str)
+            .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
     }
@@ -2442,7 +2434,7 @@ pub fn run() {
             copy_image_to_assets,
             save_clipboard_image,
             open_folder_dialog,
-            reveal_in_file_manager,
+            open_in_file_manager,
             open_url_safe,
             git_is_available,
             git_get_status,

--- a/src/components/command-palette/CommandPalette.tsx
+++ b/src/components/command-palette/CommandPalette.tsx
@@ -43,6 +43,7 @@ import {
   ClaudeIcon,
   ZenIcon,
   MarkdownIcon,
+  FolderIcon,
 } from "../icons";
 import { mod, shift } from "../../lib/platform";
 
@@ -82,6 +83,7 @@ export function CommandPalette({
     refreshNotes,
     pinNote,
     unpinNote,
+    notesFolder,
   } = useNotes();
   const { theme, setTheme } = useTheme();
   const { status, gitAvailable, commit, push } = useGit();
@@ -350,6 +352,24 @@ export function CommandPalette({
       },
     );
 
+    // Open notes folder
+    if (notesFolder) {
+      baseCommands.push({
+        id: "open-folder",
+        label: "Open Notes Folder",
+        icon: <FolderIcon className="w-4.5 h-4.5 stroke-[1.5]" />,
+        action: async () => {
+          try {
+            await invoke("open_in_file_manager", { path: notesFolder });
+            onClose();
+          } catch (error) {
+            console.error("Failed to open folder:", error);
+            toast.error("Failed to open folder");
+          }
+        },
+      });
+    }
+
     // Settings and theme commands at the bottom
     baseCommands.push(
       {
@@ -412,6 +432,7 @@ export function CommandPalette({
     unpinNote,
     focusMode,
     onToggleFocusMode,
+    notesFolder,
   ]);
 
   // Debounced search using Tantivy (local state, doesn't affect sidebar)

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -135,7 +135,7 @@ export function GeneralSettingsSection() {
   const handleOpenFolder = async () => {
     if (!notesFolder) return;
     try {
-      await invoke("reveal_in_file_manager", { path: notesFolder });
+      await invoke("open_in_file_manager", { path: notesFolder });
     } catch (err) {
       console.error("Failed to open folder:", err);
       toast.error("Failed to open folder");


### PR DESCRIPTION
## Summary
- **Fix**: "Open Folder" in settings now opens *into* the notes folder instead of selecting it in the parent directory. Replaced `reveal_in_file_manager` (`open -R`) with new `open_in_file_manager` (`open`) command that navigates directly into the directory on all platforms.
- **Feature**: Added "Open Notes Folder" command to the command palette (Cmd+P).
- **Cleanup**: Removed unused `reveal_in_file_manager` command.

## Test plan
- [ ] Open Settings → General → click "Open Folder" → verify it opens into the notes directory (not the parent)
- [ ] Open command palette (Cmd+P) → search "Open Notes Folder" → verify it opens the notes directory
- [ ] Test on macOS (and Windows/Linux if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open Notes Folder" command in the command palette for quick access to your notes directory via the system file manager.

* **Improvements**
  * Updated file and folder opening behavior on Linux, macOS, and Windows platforms for more consistent and intuitive cross-platform functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->