### PR TITLE
Enable image serving from notes folder via asset protocol

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -774,6 +774,9 @@ fn set_notes_folder(app: AppHandle, path: String, state: State<AppState>) -> Res
         save_app_config(&app, &app_config).map_err(|e| e.to_string())?;
     }
 
+    // Add notes folder to asset protocol scope so images can be served
+    let _ = app.asset_protocol_scope().allow_directory(&path_buf, true);
+
     // Initialize search index
     if let Ok(index_path) = get_search_index_path(&app) {
         if let Ok(search_index) = SearchIndex::new(&index_path) {
@@ -2461,6 +2464,11 @@ pub fn run() {
                 debounce_map: Arc::new(Mutex::new(HashMap::new())),
             };
             app.manage(state);
+
+            // Add notes folder to asset protocol scope so images can be served
+            if let Some(ref folder) = app.state::<AppState>().app_config.read().expect("app_config read lock").notes_folder.clone() {
+                let _ = app.asset_protocol_scope().allow_directory(folder, true);
+            }
 
             // Handle CLI args on first launch
             let args: Vec<String> = std::env::args().collect();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' ipc: http://ipc.localhost; img-src 'self' asset: http://asset.localhost data:; style-src 'self' 'unsafe-inline'",
+      "csp": "default-src 'self' ipc: http://ipc.localhost https://ipc.localhost; img-src 'self' asset: http://asset.localhost https://asset.localhost data:; style-src 'self' 'unsafe-inline'",
       "assetProtocol": {
         "enable": true,
         "scope": {


### PR DESCRIPTION
## Summary
This PR enables the application to serve images from the user's notes folder by adding the notes directory to the asset protocol scope and updating the Content Security Policy (CSP) to allow HTTPS asset requests.

## Key Changes
- **Asset Protocol Scope**: Added the notes folder to the asset protocol scope in two locations:
  - In `set_notes_folder()` when the user changes the notes folder path
  - During app initialization to ensure the current notes folder is accessible
- **Content Security Policy**: Updated CSP in `tauri.conf.json` to allow HTTPS requests for both `ipc.localhost` and `asset.localhost`, enabling secure image serving from the asset protocol

## Implementation Details
- The `allow_directory()` calls use `true` for the `recursive` parameter to allow access to all subdirectories within the notes folder
- Error handling uses `let _ =` pattern to gracefully ignore failures in adding the directory to the scope
- The initialization code safely reads the app config with proper lock handling before attempting to add the directory

https://claude.ai/code/session_016LwfyZaMmUnBRWH2tPLeKQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images and assets stored in notes folder can now be accessed and displayed within the application.

* **Security**
  * Enhanced security protocol support by enabling HTTPS for local connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->