### PR TITLE
Include mise path in candidate node dirs

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1983,10 +1983,11 @@ fn get_expanded_path() -> String {
         return system_path;
     }
 
-    // Common locations for node-installed CLIs (nvm, volta, fnm, homebrew, global npm)
+    // Common locations for node-installed CLIs (nvm, volta, fnm, mise, homebrew, global npm)
     let candidate_dirs = vec![
         format!("{home}/.nvm/versions/node"),
         format!("{home}/.fnm/node-versions"),
+        format!("{home}/.local/share/mise/installs/node"),
     ];
     let static_dirs = vec![
         format!("{home}/.volta/bin"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node command-line tool discovery to include tools installed via mise package manager, ensuring better compatibility with alternative Node installation methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->