### PR TITLE
Add drag-and-drop markdown file import

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,6 +104,8 @@ pub struct Settings {
     pub default_note_name: Option<String>,
     #[serde(rename = "interfaceZoom")]
     pub interface_zoom: Option<f32>,
+    #[serde(rename = "dragDropBehavior")]
+    pub drag_drop_behavior: Option<String>, // "import" | "preview", default "import"
 }
 
 // Search result
@@ -2338,6 +2340,70 @@ fn try_select_in_notes_folder(app: &AppHandle, path: &Path) -> bool {
     true
 }
 
+/// Import an external markdown file into the notes folder.
+/// Copies the file content, handles filename conflicts, updates the search index,
+/// and emits a "select-note" event to auto-select the imported note.
+fn import_markdown_file(app: &AppHandle, source_path: &Path) -> Result<(), String> {
+    let state = app
+        .try_state::<AppState>()
+        .ok_or("AppState not available")?;
+
+    let notes_folder = {
+        let config = state.app_config.read().expect("app_config read lock");
+        config.notes_folder.clone().ok_or("Notes folder not set")?
+    };
+    let folder_path = PathBuf::from(&notes_folder);
+
+    // Read source file content
+    let content = std::fs::read_to_string(source_path)
+        .map_err(|e| format!("Failed to read source file: {}", e))?;
+
+    // Use the source filename stem as the base ID, sanitized for filesystem safety
+    let stem = source_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("Untitled");
+    let base_id = sanitize_filename(stem);
+
+    // Handle filename conflicts with numeric suffix (same pattern as create_note)
+    let mut final_id = base_id.clone();
+    let mut counter = 1;
+    while abs_path_from_id(&folder_path, &final_id)
+        .map(|p| p.exists())
+        .unwrap_or(false)
+    {
+        final_id = format!("{}-{}", base_id, counter);
+        counter += 1;
+    }
+
+    let dest_path = abs_path_from_id(&folder_path, &final_id)?;
+
+    // Write the file
+    std::fs::write(&dest_path, &content)
+        .map_err(|e| format!("Failed to write imported file: {}", e))?;
+
+    // Update search index
+    let title = extract_title(&content);
+    let modified = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    {
+        let index = state.search_index.lock().expect("search index mutex");
+        if let Some(ref search_index) = *index {
+            let _ = search_index.index_note(&final_id, &title, &content, modified);
+        }
+    }
+
+    // Emit select-note to auto-select in sidebar, then focus main window
+    let _ = app.emit_to("main", "select-note", &final_id);
+    if let Some(main_window) = app.get_webview_window("main") {
+        let _ = main_window.set_focus();
+    }
+
+    Ok(())
+}
+
 /// Check if a file extension is a supported markdown extension.
 fn is_markdown_extension(path: &Path) -> bool {
     path.extension()
@@ -2540,7 +2606,27 @@ pub fn run() {
                         && path.is_file()
                         && !try_select_in_notes_folder(app, path)
                     {
-                        let _ = create_preview_window(app, &path.to_string_lossy());
+                        // Check setting for drag-drop behavior
+                        let behavior = app
+                            .try_state::<AppState>()
+                            .and_then(|state| {
+                                state
+                                    .settings
+                                    .read()
+                                    .ok()
+                                    .and_then(|s| s.drag_drop_behavior.clone())
+                            })
+                            .unwrap_or_else(|| "import".to_string());
+
+                        if behavior == "preview" {
+                            let _ = create_preview_window(app, &path.to_string_lossy());
+                        } else {
+                            // Default: import into notes folder, fall back to preview on error
+                            if let Err(e) = import_markdown_file(app, path) {
+                                eprintln!("Failed to import markdown file: {}", e);
+                                let _ = create_preview_window(app, &path.to_string_lossy());
+                            }
+                        }
                     }
                 }
             }
@@ -2597,7 +2683,27 @@ pub fn run() {
                         && path.is_file()
                         && !try_select_in_notes_folder(_app_handle, &path)
                     {
-                        let _ = create_preview_window(_app_handle, &path.to_string_lossy());
+                        let behavior = _app_handle
+                            .try_state::<AppState>()
+                            .and_then(|state| {
+                                state
+                                    .settings
+                                    .read()
+                                    .ok()
+                                    .and_then(|s| s.drag_drop_behavior.clone())
+                            })
+                            .unwrap_or_else(|| "import".to_string());
+
+                        if behavior == "preview" {
+                            let _ =
+                                create_preview_window(_app_handle, &path.to_string_lossy());
+                        } else if let Err(e) = import_markdown_file(_app_handle, &path) {
+                            eprintln!("Failed to import markdown file: {}", e);
+                            let _ = create_preview_window(
+                                _app_handle,
+                                &path.to_string_lossy(),
+                            );
+                        }
                     }
                 }
             }

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -63,23 +63,27 @@ export function GeneralSettingsSection() {
   const [showRemoteInput, setShowRemoteInput] = useState(false);
   const [noteTemplate, setNoteTemplate] = useState<string>("Untitled");
   const [previewNoteName, setPreviewNoteName] = useState<string>("Untitled");
+  const [dragDropBehavior, setDragDropBehavior] = useState<"import" | "preview">(
+    "import"
+  );
 
-  // Load template from settings on mount
+  // Load settings on mount
   useEffect(() => {
-    const loadTemplate = async () => {
+    const loadSettings = async () => {
       try {
         const settings = await invoke<Settings>("get_settings");
         const template = settings.defaultNoteName || "Untitled";
         setNoteTemplate(template);
+        setDragDropBehavior(settings.dragDropBehavior || "import");
 
         // Update preview
         const preview = await invoke<string>("preview_note_name", { template });
         setPreviewNoteName(preview);
       } catch (error) {
-        console.error("Failed to load template:", error);
+        console.error("Failed to load settings:", error);
       }
     };
-    loadTemplate();
+    loadSettings();
   }, []);
 
   // Update preview when template changes (debounced)
@@ -112,6 +116,22 @@ export function GeneralSettingsSection() {
     } catch (error) {
       console.error("Failed to save default name:", error);
       toast.error("Failed to save default name");
+    }
+  };
+
+  const handleDragDropChange = async (value: "import" | "preview") => {
+    setDragDropBehavior(value);
+    try {
+      const settings = await invoke<Settings>("get_settings");
+      await invoke("update_settings", {
+        newSettings: {
+          ...settings,
+          dragDropBehavior: value,
+        },
+      });
+    } catch (error) {
+      console.error("Failed to save drag & drop setting:", error);
+      toast.error("Failed to save setting");
     }
   };
 
@@ -223,6 +243,52 @@ export function GeneralSettingsSection() {
               Open Folder
             </Button>
           )}
+        </div>
+      </section>
+
+      {/* Divider */}
+      <div className="border-t border-border border-dashed" />
+
+      {/* Drag & Drop Behavior */}
+      <section className="pb-2">
+        <h2 className="text-xl font-medium mb-0.5">Drag & Drop</h2>
+        <p className="text-sm text-text-muted mb-4">
+          Choose what happens when you drop markdown files onto Scratch
+        </p>
+        <div className="space-y-2">
+          <label className="flex items-center gap-3 p-2.5 rounded-[10px] border border-border cursor-pointer hover:bg-bg-muted transition-colors">
+            <input
+              type="radio"
+              name="dragDropBehavior"
+              value="import"
+              checked={dragDropBehavior !== "preview"}
+              onChange={() => handleDragDropChange("import")}
+              className="accent-accent"
+            />
+            <div>
+              <p className="text-sm font-medium">Import into notes folder</p>
+              <p className="text-xs text-text-muted">
+                Copy the file into your notes folder so it appears in the
+                sidebar
+              </p>
+            </div>
+          </label>
+          <label className="flex items-center gap-3 p-2.5 rounded-[10px] border border-border cursor-pointer hover:bg-bg-muted transition-colors">
+            <input
+              type="radio"
+              name="dragDropBehavior"
+              value="preview"
+              checked={dragDropBehavior === "preview"}
+              onChange={() => handleDragDropChange("preview")}
+              className="accent-accent"
+            />
+            <div>
+              <p className="text-sm font-medium">Open in preview window</p>
+              <p className="text-xs text-text-muted">
+                View the file in a separate window without copying it
+              </p>
+            </div>
+          </label>
         </div>
       </section>
 

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -38,4 +38,5 @@ export interface Settings {
   editorWidth?: EditorWidth;
   defaultNoteName?: string;
   interfaceZoom?: number;
+  dragDropBehavior?: "import" | "preview";
 }


### PR DESCRIPTION
## Summary
- Dropping `.md` files onto Scratch from outside the notes folder now **imports** (copies) them into the notes folder, with filename conflict handling and auto-selection
- Adds a configurable setting in **Settings > General > Drag & Drop** to choose between "Import into notes folder" (new default) and "Open in preview window" (previous behavior)
- Also applies to macOS "Open With" file associations

Closes #60

## Test plan
- [ ] Drop a `.md` file from Finder onto Scratch — verify it appears in the sidebar and is auto-selected
- [ ] Drop a file whose name already exists — verify it gets a `-1` suffix
- [ ] Drop multiple `.md` files at once — verify all appear in the sidebar
- [ ] Change setting to "Open in preview window" — verify dropping opens a preview instead
- [ ] Drop a file already in the notes folder — verify it just selects it (no duplication)
- [ ] Drop a non-markdown file — verify it is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added drag-and-drop behavior setting: choose between importing markdown files to your notes folder or opening them in a preview window.
  * New settings section with radio button controls to configure drag-and-drop behavior.
  * Default behavior imports files; failed imports automatically fall back to preview for seamless usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->