### PR TITLE
fix: prevent hidden filenames from heading titles

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -335,16 +335,11 @@ fn sanitize_filename(title: &str) -> String {
         })
         .collect();
 
-    // Prevent creating hidden note files like ".foo.md".
-    // Titles can still start with "." in content; only filename stems are normalized.
-    let normalized = sanitized
-        .trim()
-        .trim_start_matches(|c: char| c == '.' || c.is_whitespace());
-
-    if normalized.is_empty() || is_effectively_empty(normalized) {
+    let trimmed = sanitized.trim();
+    if trimmed.is_empty() || is_effectively_empty(trimmed) {
         "Untitled".to_string()
     } else {
-        normalized.to_string()
+        trimmed.to_string()
     }
 }
 
@@ -552,11 +547,14 @@ fn strip_markdown(text: &str) -> String {
     result.trim().to_string()
 }
 
-/// Filter for WalkDir: skips dot-directories (e.g. .scratch, .git) and assets/.
+/// Directories to exclude from note discovery and ID resolution.
+const EXCLUDED_DIRS: &[&str] = &[".git", ".scratch", ".obsidian", ".trash", "assets"];
+
+/// Filter for WalkDir: skips excluded directories.
 fn is_visible_notes_entry(entry: &walkdir::DirEntry) -> bool {
     if entry.file_type().is_dir() {
         let name = entry.file_name().to_str().unwrap_or("");
-        return !name.starts_with('.') && name != "assets";
+        return !EXCLUDED_DIRS.contains(&name);
     }
     true
 }
@@ -566,11 +564,12 @@ fn is_visible_notes_entry(entry: &walkdir::DirEntry) -> bool {
 fn id_from_abs_path(notes_root: &Path, file_path: &Path) -> Option<String> {
     let rel = file_path.strip_prefix(notes_root).ok()?;
 
-    // Skip excluded directories (dot-dirs catch .scratch, .git, etc.)
-    for component in rel.components() {
+    // Skip files inside excluded directories (.git, .scratch, assets, etc.)
+    // Only block specific known dirs so that dot-prefixed *files* like ".foo.md" are still visible.
+    for component in rel.parent().unwrap_or(Path::new("")).components() {
         if let std::path::Component::Normal(name) = component {
             let name_str = name.to_str()?;
-            if name_str.starts_with('.') || name_str == "assets" {
+            if EXCLUDED_DIRS.contains(&name_str) {
                 return None;
             }
         }


### PR DESCRIPTION
fix: #61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of which folders are excluded from note lists, ensuring common system/project folders are ignored while dot-prefixed note files remain visible.
  * Preserved visibility for files whose names start with a dot so legitimate notes (e.g., ".foo.md") are accessible.
  * Continued normalization of empty or dot-prefixed titles to prevent hidden or invalid filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->