### PR TITLE
feat: add heading level indicators to the editor

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -270,6 +270,15 @@ html.dark {
 }
 
 /* Headings - all use the same font family with computed sizes */
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4,
+.prose h5,
+.prose h6 {
+  position: relative;
+}
+
 .prose h1 {
   font-family: var(--editor-font-family);
   font-size: var(--editor-h1-size);
@@ -314,6 +323,34 @@ html.dark {
   line-height: 1.3;
   margin-top: 0.5em;
   margin-bottom: 0.25em;
+}
+
+/* Heading level indicators */
+.heading-level-indicator {
+  position: absolute;
+  left: -3.5rem;
+  width: 3rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  user-select: none;
+  pointer-events: none;
+  font-family: var(--font-mono);
+  opacity: 0.5;
+  transition: opacity 0.15s;
+  text-align: right;
+  padding-right: 0.5rem;
+}
+
+.prose h1:hover,
+.prose h2:hover,
+.prose h3:hover,
+.prose h4:hover,
+.prose h5:hover,
+.prose h6:hover {
+  & .heading-level-indicator {
+    opacity: 0.8;
+  }
 }
 
 /* Bold text uses the same weight as headings */

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -43,6 +43,7 @@ import { SearchToolbar } from "./SearchToolbar";
 import { SlashCommand } from "./SlashCommand";
 import { Wikilink, type WikilinkStorage } from "./Wikilink";
 import { WikilinkSuggestion } from "./WikilinkSuggestion";
+import { HeadingLevel } from "./HeadingLevel";
 import { cn } from "../../lib/utils";
 import { plainTextFromMarkdown } from "../../lib/plainText";
 import { Button, IconButton, ToolbarButton, Tooltip } from "../ui";
@@ -678,6 +679,7 @@ export function Editor({
       SlashCommand,
       Wikilink,
       WikilinkSuggestion,
+      HeadingLevel,
     ],
     editorProps: {
       attributes: {

--- a/src/components/editor/HeadingLevel.tsx
+++ b/src/components/editor/HeadingLevel.tsx
@@ -1,0 +1,48 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/**
+ * Extension that adds heading level indicators (H1, H2, etc.) to the left of headings
+ */
+export const HeadingLevel = Extension.create({
+  name: "headingLevel",
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey("headingLevel"),
+        props: {
+          decorations: (state) => {
+            const decorations: Decoration[] = [];
+            const { doc } = state;
+
+            doc.descendants((node, pos) => {
+              if (node.type.name === "heading") {
+                const level = node.attrs.level;
+                const decoration = Decoration.widget(
+                  pos + 1,
+                  () => {
+                    const span = document.createElement("span");
+                    span.className = "heading-level-indicator";
+                    span.textContent = `H${level}`;
+                    span.contentEditable = "false";
+                    span.setAttribute("data-heading-level", level.toString());
+                    return span;
+                  },
+                  {
+                    side: -1,
+                    key: `heading-level-${pos}`,
+                  }
+                );
+                decorations.push(decoration);
+              }
+            });
+
+            return DecorationSet.create(doc, decorations);
+          },
+        },
+      }),
+    ];
+  },
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heading level indicators (H1–H6) that appear on hover next to headings in the editor, helping users visualize document structure at a glance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->