### PR TITLE
feat: split settings into global (user prefs) and local (per-folder)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -694,11 +694,19 @@ fn get_app_config_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_data.join("config.json"))
 }
 
-// Get global settings file path (in app config directory, shared across all folders)
-fn get_global_settings_path(app: &AppHandle) -> Result<PathBuf> {
-    let app_data = app.path().app_data_dir()?;
-    std::fs::create_dir_all(&app_data)?;
-    Ok(app_data.join("settings.json"))
+// Get global settings directory (~/.config/scratch/), survives app uninstall/reinstall
+fn get_global_settings_dir() -> Result<PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map_err(|_| anyhow::anyhow!("Cannot determine home directory"))?;
+    let dir = PathBuf::from(home).join(".config").join("scratch");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+// Get global settings file path (~/.config/scratch/settings.json, shared across all folders)
+fn get_global_settings_path() -> Result<PathBuf> {
+    Ok(get_global_settings_dir()?.join("settings.json"))
 }
 
 // Get per-folder settings file path (in .scratch/ within notes folder)
@@ -741,8 +749,8 @@ fn save_app_config(app: &AppHandle, config: &AppConfig) -> Result<()> {
 }
 
 // Load global settings from disk (shared across all notes folders)
-fn load_global_settings(app: &AppHandle) -> GlobalSettings {
-    let path = match get_global_settings_path(app) {
+fn load_global_settings() -> GlobalSettings {
+    let path = match get_global_settings_path() {
         Ok(p) => p,
         Err(_) => return GlobalSettings::default(),
     };
@@ -758,11 +766,37 @@ fn load_global_settings(app: &AppHandle) -> GlobalSettings {
 }
 
 // Save global settings to disk
-fn save_global_settings(app: &AppHandle, settings: &GlobalSettings) -> Result<()> {
-    let path = get_global_settings_path(app)?;
+fn save_global_settings(settings: &GlobalSettings) -> Result<()> {
+    let path = get_global_settings_path()?;
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())
+}
+
+// Migrate global settings from old Tauri app_data location to ~/.config/scratch/
+fn migrate_global_settings(app: &AppHandle) {
+    let new_path = match get_global_settings_path() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    // Already migrated or fresh install
+    if new_path.exists() {
+        return;
+    }
+
+    // Check old location (Tauri app_data_dir)
+    let old_path = match app.path().app_data_dir() {
+        Ok(dir) => dir.join("settings.json"),
+        Err(_) => return,
+    };
+
+    if old_path.exists() {
+        if let Ok(content) = std::fs::read_to_string(&old_path) {
+            let _ = std::fs::write(&new_path, content);
+            eprintln!("Migrated global settings from {:?} to {:?}", old_path, new_path);
+        }
+    }
 }
 
 // Load per-folder settings from disk
@@ -1751,7 +1785,6 @@ fn get_settings(state: State<AppState>) -> Settings {
 fn update_settings(
     new_settings: Settings,
     state: State<AppState>,
-    app: AppHandle,
 ) -> Result<(), String> {
     let new_global = GlobalSettings {
         theme: new_settings.theme,
@@ -1775,7 +1808,7 @@ fn update_settings(
         let mut global = state.global_settings.write().expect("global_settings write lock");
         *global = new_global.clone();
     }
-    save_global_settings(&app, &new_global).map_err(|e| e.to_string())?;
+    save_global_settings(&new_global).map_err(|e| e.to_string())?;
 
     // Save local settings only if a notes folder is active
     let folder = {
@@ -3681,8 +3714,11 @@ pub fn run() {
                 }
             }
 
+            // Migrate global settings from old app_data location to ~/.config/scratch/
+            migrate_global_settings(app.handle());
+
             // Load global settings (shared across all notes folders)
-            let global_settings = load_global_settings(app.handle());
+            let global_settings = load_global_settings();
 
             // Load per-folder settings if notes folder is set
             let local_settings = if let Some(ref folder) = app_config.notes_folder {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1494,7 +1494,9 @@ async fn rename_folder(
                 }
             }
         }
-        let _ = save_local_settings(&folder, &local);
+        if let Err(e) = save_local_settings(&folder, &local) {
+            eprintln!("Warning: failed to persist pinned note IDs: {}", e);
+        }
     }
 
     // Update cache
@@ -1588,7 +1590,9 @@ async fn move_note(
                 }
             }
         }
-        let _ = save_local_settings(&folder, &local);
+        if let Err(e) = save_local_settings(&folder, &local) {
+            eprintln!("Warning: failed to persist pinned note IDs: {}", e);
+        }
     }
 
     // Update cache
@@ -1689,7 +1693,9 @@ async fn move_folder(
                 }
             }
         }
-        let _ = save_local_settings(&folder, &local);
+        if let Err(e) = save_local_settings(&folder, &local) {
+            eprintln!("Warning: failed to persist pinned note IDs: {}", e);
+        }
     }
 
     // Update cache

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,7 +102,40 @@ pub struct AppConfig {
     pub notes_folder: Option<String>,
 }
 
-// Per-folder settings (stored in .scratch/settings.json within notes folder)
+// Global settings – stored in {APP_CONFIG_DIR}/settings.json
+// These are user preferences shared across all notes folders.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GlobalSettings {
+    pub theme: ThemeSettings,
+    #[serde(rename = "editorFont")]
+    pub editor_font: Option<EditorFontSettings>,
+    #[serde(rename = "textDirection")]
+    pub text_direction: Option<TextDirection>,
+    #[serde(rename = "editorWidth")]
+    pub editor_width: Option<String>,
+    #[serde(rename = "customEditorWidthPx")]
+    pub custom_editor_width_px: Option<u32>,
+    #[serde(rename = "interfaceZoom")]
+    pub interface_zoom: Option<f32>,
+    #[serde(rename = "ollamaModel")]
+    pub ollama_model: Option<String>,
+    #[serde(rename = "foldersEnabled")]
+    pub folders_enabled: Option<bool>,
+}
+
+// Local settings – stored in {NOTES_FOLDER}/.scratch/settings.json
+// These are specific to the active notes folder.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct LocalSettings {
+    #[serde(rename = "gitEnabled")]
+    pub git_enabled: Option<bool>,
+    #[serde(rename = "pinnedNoteIds")]
+    pub pinned_note_ids: Option<Vec<String>>,
+    #[serde(rename = "defaultNoteName")]
+    pub default_note_name: Option<String>,
+}
+
+// Combined settings – used as the API contract with the frontend (unchanged shape).
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {
     pub theme: ThemeSettings,
@@ -325,8 +358,9 @@ impl SearchIndex {
 
 // App state with improved structure
 pub struct AppState {
-    pub app_config: RwLock<AppConfig>,  // notes_folder path (stored in app data)
-    pub settings: RwLock<Settings>,      // per-folder settings (stored in .scratch/)
+    pub app_config: RwLock<AppConfig>,           // notes_folder path (stored in app data)
+    pub global_settings: RwLock<GlobalSettings>, // user prefs shared across folders
+    pub local_settings: RwLock<LocalSettings>,   // per-folder settings (stored in .scratch/)
     pub notes_cache: RwLock<HashMap<String, NoteMetadata>>,
     pub file_watcher: Mutex<Option<FileWatcherState>>,
     pub search_index: Mutex<Option<SearchIndex>>,
@@ -337,7 +371,8 @@ impl Default for AppState {
     fn default() -> Self {
         Self {
             app_config: RwLock::new(AppConfig::default()),
-            settings: RwLock::new(Settings::default()),
+            global_settings: RwLock::new(GlobalSettings::default()),
+            local_settings: RwLock::new(LocalSettings::default()),
             notes_cache: RwLock::new(HashMap::new()),
             file_watcher: Mutex::new(None),
             search_index: Mutex::new(None),
@@ -659,8 +694,15 @@ fn get_app_config_path(app: &AppHandle) -> Result<PathBuf> {
     Ok(app_data.join("config.json"))
 }
 
+// Get global settings file path (in app config directory, shared across all folders)
+fn get_global_settings_path(app: &AppHandle) -> Result<PathBuf> {
+    let app_data = app.path().app_data_dir()?;
+    std::fs::create_dir_all(&app_data)?;
+    Ok(app_data.join("settings.json"))
+}
+
 // Get per-folder settings file path (in .scratch/ within notes folder)
-fn get_settings_path(notes_folder: &str) -> PathBuf {
+fn get_local_settings_path(notes_folder: &str) -> PathBuf {
     let scratch_dir = PathBuf::from(notes_folder).join(".scratch");
     std::fs::create_dir_all(&scratch_dir).ok();
     scratch_dir.join("settings.json")
@@ -698,9 +740,12 @@ fn save_app_config(app: &AppHandle, config: &AppConfig) -> Result<()> {
     Ok(())
 }
 
-// Load per-folder settings from disk
-fn load_settings(notes_folder: &str) -> Settings {
-    let path = get_settings_path(notes_folder);
+// Load global settings from disk (shared across all notes folders)
+fn load_global_settings(app: &AppHandle) -> GlobalSettings {
+    let path = match get_global_settings_path(app) {
+        Ok(p) => p,
+        Err(_) => return GlobalSettings::default(),
+    };
 
     if path.exists() {
         std::fs::read_to_string(&path)
@@ -708,13 +753,35 @@ fn load_settings(notes_folder: &str) -> Settings {
             .and_then(|content| serde_json::from_str(&content).ok())
             .unwrap_or_default()
     } else {
-        Settings::default()
+        GlobalSettings::default()
+    }
+}
+
+// Save global settings to disk
+fn save_global_settings(app: &AppHandle, settings: &GlobalSettings) -> Result<()> {
+    let path = get_global_settings_path(app)?;
+    let content = serde_json::to_string_pretty(settings)?;
+    std::fs::write(path, content)?;
+    Ok(())
+}
+
+// Load per-folder settings from disk
+fn load_local_settings(notes_folder: &str) -> LocalSettings {
+    let path = get_local_settings_path(notes_folder);
+
+    if path.exists() {
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok())
+            .unwrap_or_default()
+    } else {
+        LocalSettings::default()
     }
 }
 
 // Save per-folder settings to disk
-fn save_settings(notes_folder: &str, settings: &Settings) -> Result<()> {
-    let path = get_settings_path(notes_folder);
+fn save_local_settings(notes_folder: &str, settings: &LocalSettings) -> Result<()> {
+    let path = get_local_settings_path(notes_folder);
     let content = serde_json::to_string_pretty(settings)?;
     std::fs::write(path, content)?;
     Ok(())
@@ -771,7 +838,7 @@ fn initialize_notes_folder(app: &AppHandle, path_buf: &PathBuf, state: &AppState
     let _ = std::fs::remove_file(&write_test_path);
 
     // Load per-folder settings (starts fresh with defaults if none exist)
-    let settings = load_settings(&normalized_path);
+    let local = load_local_settings(&normalized_path);
 
     // Update app config
     {
@@ -779,10 +846,10 @@ fn initialize_notes_folder(app: &AppHandle, path_buf: &PathBuf, state: &AppState
         app_config.notes_folder = Some(normalized_path.clone());
     }
 
-    // Update settings in memory
+    // Update local settings in memory (global settings are loaded once at startup)
     {
-        let mut current_settings = state.settings.write().expect("settings write lock");
-        *current_settings = settings;
+        let mut local_settings = state.local_settings.write().expect("local_settings write lock");
+        *local_settings = local;
     }
 
     // Save app config to disk
@@ -884,10 +951,10 @@ async fn list_notes(state: State<'_, AppState>) -> Result<Vec<NoteMetadata>, Str
         })
         .collect();
 
-    // Load pinned note IDs from settings
+    // Load pinned note IDs from local settings
     let pinned_ids: HashSet<String> = {
-        let settings = state.settings.read().expect("settings read lock");
-        settings
+        let local = state.local_settings.read().expect("local_settings read lock");
+        local
             .pinned_note_ids
             .as_ref()
             .map(|ids| ids.iter().cloned().collect())
@@ -1120,10 +1187,10 @@ async fn create_note(target_folder: Option<String>, state: State<'_, AppState>) 
     };
     let folder_path = PathBuf::from(&folder);
 
-    // Get template from settings (default "Untitled")
+    // Get template from local settings (default "Untitled")
     let template = {
-        let settings = state.settings.read().expect("settings read lock");
-        settings
+        let local = state.local_settings.read().expect("local_settings read lock");
+        local
             .default_note_name
             .clone()
             .unwrap_or_else(|| "Untitled".to_string())
@@ -1415,10 +1482,10 @@ async fn rename_folder(
         .await
         .map_err(|e| e.to_string())?;
 
-    // Update pinned note IDs in settings
+    // Update pinned note IDs in local settings
     {
-        let mut settings = state.settings.write().expect("settings write lock");
-        if let Some(ref mut pinned) = settings.pinned_note_ids {
+        let mut local = state.local_settings.write().expect("local_settings write lock");
+        if let Some(ref mut pinned) = local.pinned_note_ids {
             for id in pinned.iter_mut() {
                 if id.starts_with(&old_prefix) {
                     *id = format!("{}{}", new_prefix, &id[old_prefix.len()..]);
@@ -1427,8 +1494,7 @@ async fn rename_folder(
                 }
             }
         }
-        // Save settings
-        let _ = save_settings(&folder, &settings);
+        let _ = save_local_settings(&folder, &local);
     }
 
     // Update cache
@@ -1512,17 +1578,17 @@ async fn move_note(
         .await
         .map_err(|e| e.to_string())?;
 
-    // Update pinned note IDs
+    // Update pinned note IDs in local settings
     {
-        let mut settings = state.settings.write().expect("settings write lock");
-        if let Some(ref mut pinned) = settings.pinned_note_ids {
+        let mut local = state.local_settings.write().expect("local_settings write lock");
+        if let Some(ref mut pinned) = local.pinned_note_ids {
             for pin_id in pinned.iter_mut() {
                 if *pin_id == id {
                     *pin_id = new_id.clone();
                 }
             }
         }
-        let _ = save_settings(&folder, &settings);
+        let _ = save_local_settings(&folder, &local);
     }
 
     // Update cache
@@ -1613,17 +1679,17 @@ async fn move_folder(
         .await
         .map_err(|e| e.to_string())?;
 
-    // Update pinned note IDs
+    // Update pinned note IDs in local settings
     {
-        let mut settings = state.settings.write().expect("settings write lock");
-        if let Some(ref mut pinned) = settings.pinned_note_ids {
+        let mut local = state.local_settings.write().expect("local_settings write lock");
+        if let Some(ref mut pinned) = local.pinned_note_ids {
             for pin_id in pinned.iter_mut() {
                 if pin_id.starts_with(&old_prefix) {
                     *pin_id = format!("{}{}", new_prefix, &pin_id[old_prefix.len()..]);
                 }
             }
         }
-        let _ = save_settings(&folder, &settings);
+        let _ = save_local_settings(&folder, &local);
     }
 
     // Update cache
@@ -1658,26 +1724,65 @@ async fn move_folder(
 
 #[tauri::command]
 fn get_settings(state: State<AppState>) -> Settings {
-    state.settings.read().expect("settings read lock").clone()
+    let global = state.global_settings.read().expect("global_settings read lock").clone();
+    let local = state.local_settings.read().expect("local_settings read lock").clone();
+    Settings {
+        theme: global.theme,
+        editor_font: global.editor_font,
+        text_direction: global.text_direction,
+        editor_width: global.editor_width,
+        custom_editor_width_px: global.custom_editor_width_px,
+        interface_zoom: global.interface_zoom,
+        ollama_model: global.ollama_model,
+        folders_enabled: global.folders_enabled,
+        git_enabled: local.git_enabled,
+        pinned_note_ids: local.pinned_note_ids,
+        default_note_name: local.default_note_name,
+    }
 }
 
 #[tauri::command]
 fn update_settings(
     new_settings: Settings,
     state: State<AppState>,
+    app: AppHandle,
 ) -> Result<(), String> {
-    let folder = {
-        let app_config = state.app_config.read().expect("app_config read lock");
-        app_config.notes_folder.clone().ok_or("Notes folder not set")?
+    let new_global = GlobalSettings {
+        theme: new_settings.theme,
+        editor_font: new_settings.editor_font,
+        text_direction: new_settings.text_direction,
+        editor_width: new_settings.editor_width,
+        custom_editor_width_px: new_settings.custom_editor_width_px,
+        interface_zoom: new_settings.interface_zoom,
+        ollama_model: new_settings.ollama_model,
+        folders_enabled: new_settings.folders_enabled,
     };
 
-    {
-        let mut settings = state.settings.write().expect("settings write lock");
-        *settings = new_settings;
-    }
+    let new_local = LocalSettings {
+        git_enabled: new_settings.git_enabled,
+        pinned_note_ids: new_settings.pinned_note_ids,
+        default_note_name: new_settings.default_note_name,
+    };
 
-    let settings = state.settings.read().expect("settings read lock");
-    save_settings(&folder, &settings).map_err(|e| e.to_string())?;
+    // Save global settings
+    {
+        let mut global = state.global_settings.write().expect("global_settings write lock");
+        *global = new_global.clone();
+    }
+    save_global_settings(&app, &new_global).map_err(|e| e.to_string())?;
+
+    // Save local settings only if a notes folder is active
+    let folder = {
+        let app_config = state.app_config.read().expect("app_config read lock");
+        app_config.notes_folder.clone()
+    };
+    if let Some(folder) = folder {
+        {
+            let mut local = state.local_settings.write().expect("local_settings write lock");
+            *local = new_local.clone();
+        }
+        save_local_settings(&folder, &new_local).map_err(|e| e.to_string())?;
+    }
 
     Ok(())
 }
@@ -1700,12 +1805,12 @@ fn update_git_enabled(
     };
 
     {
-        let mut settings = state.settings.write().expect("settings write lock");
-        settings.git_enabled = enabled;
+        let mut local = state.local_settings.write().expect("local_settings write lock");
+        local.git_enabled = enabled;
     }
 
-    let settings = state.settings.read().expect("settings read lock");
-    save_settings(&folder, &settings).map_err(|e| e.to_string())?;
+    let local = state.local_settings.read().expect("local_settings read lock");
+    save_local_settings(&folder, &local).map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -3570,11 +3675,14 @@ pub fn run() {
                 }
             }
 
+            // Load global settings (shared across all notes folders)
+            let global_settings = load_global_settings(app.handle());
+
             // Load per-folder settings if notes folder is set
-            let settings = if let Some(ref folder) = app_config.notes_folder {
-                load_settings(folder)
+            let local_settings = if let Some(ref folder) = app_config.notes_folder {
+                load_local_settings(folder)
             } else {
-                Settings::default()
+                LocalSettings::default()
             };
 
             // Initialize search index if notes folder is set
@@ -3592,7 +3700,8 @@ pub fn run() {
 
             let state = AppState {
                 app_config: RwLock::new(app_config),
-                settings: RwLock::new(settings),
+                global_settings: RwLock::new(global_settings),
+                local_settings: RwLock::new(local_settings),
                 notes_cache: RwLock::new(HashMap::new()),
                 file_watcher: Mutex::new(None),
                 search_index: Mutex::new(search_index),

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -28,20 +28,27 @@ export interface EditorFontSettings {
   lineHeight?: number; // default 1.6
 }
 
-// Per-folder settings (stored in .scratch/settings.json)
-export interface Settings {
+// Global settings – shared across all notes folders ({APP_CONFIG_DIR}/settings.json)
+export interface GlobalSettings {
   theme: ThemeSettings;
   editorFont?: EditorFontSettings;
-  gitEnabled?: boolean;
-  foldersEnabled?: boolean;
-  pinnedNoteIds?: string[];
   textDirection?: TextDirection;
   editorWidth?: EditorWidth;
   customEditorWidthPx?: number;
-  defaultNoteName?: string;
   interfaceZoom?: number;
   ollamaModel?: string;
+  foldersEnabled?: boolean;
 }
+
+// Local settings – specific to the active notes folder (.scratch/settings.json)
+export interface LocalSettings {
+  gitEnabled?: boolean;
+  pinnedNoteIds?: string[];
+  defaultNoteName?: string;
+}
+
+// Combined settings – API contract with the backend (unchanged shape)
+export interface Settings extends GlobalSettings, LocalSettings {}
 
 export interface FolderNode {
   name: string;


### PR DESCRIPTION
Closes #121

## Problem

All settings were stored in `{NOTES_FOLDER}/.scratch/settings.json`, meaning user preferences (theme, typography, zoom, etc.) reset every time a different notes folder was selected.

## Solution

Split settings into two buckets:

### Global — `~/.config/scratch/settings.json`
Shared across all notes folders, persists regardless of which folder is active **and survives app uninstall/reinstall**:
- Theme (mode + custom colors)
- Editor font (family, size, bold weight, line height)
- Text direction
- Editor width / custom width px
- Interface zoom
- Ollama model
- Folders enabled (tree view preference)

Stored in `~/.config/scratch/` instead of the Tauri app data directory so settings are not lost when the app is uninstalled and reinstalled.

### Local — `{NOTES_FOLDER}/.scratch/settings.json`
Specific to the active notes folder:
- Git enabled
- Pinned note IDs
- Default note name template

## Implementation

- Added `GlobalSettings` and `LocalSettings` structs in Rust
- `AppState` now holds `global_settings` and `local_settings` separately
- `get_settings()` returns a merged view — **no frontend API change**
- `update_settings()` transparently splits writes to the correct file
- Global settings stored in `~/.config/scratch/settings.json` (cross-platform, persists across reinstalls)
- Automatic migration from old Tauri app data location on first launch
- Local settings reload on folder switch

## Test plan
- [x] Change theme/typography → switch notes folder → settings persist
- [ ] Pin a note in folder A → switch to folder B → pins are folder-specific
- [ ] Enable git on folder A → switch to folder B → git state is folder-specific
- [x] Verify `~/.config/scratch/settings.json` is created on first settings change
- [ ] Verify `.scratch/settings.json` only contains local fields
- [ ] Uninstall and reinstall app → global settings are preserved
- [ ] Existing users: old settings in app data dir are migrated automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings split into Global (app-wide preferences) and Local (per-folder: git, pinned notes, default note name); frontend still shows a single combined settings view.
  * One-time migration imports legacy settings into the new global location when needed.

* **Chores**
  * Global settings load at startup; local settings load when a notes folder is active. Global changes persist always; local changes persist only when a folder is set.

* **Bug Fixes**
  * Note/folder operations update and persist local settings; local persistence failures are logged instead of surfacing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->