### PR TITLE
feat: add text-based date tokens to default note name template

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -371,9 +371,19 @@ fn sanitize_filename(title: &str) -> String {
     }
 }
 
+fn ordinal_suffix(day: u32) -> &'static str {
+    match (day % 100, day % 10) {
+        (11..=13, _) => "th",
+        (_, 1) => "st",
+        (_, 2) => "nd",
+        (_, 3) => "rd",
+        _ => "th",
+    }
+}
+
 /// Expands template tags in a note name template using local timezone
 fn expand_note_name_template(template: &str) -> String {
-    use chrono::Local;
+    use chrono::{Datelike, Local};
 
     let mut result = template.to_string();
 
@@ -388,6 +398,17 @@ fn expand_note_name_template(template: &str) -> String {
     result = result.replace("{year}", &now.format("%Y").to_string());
     result = result.replace("{month}", &now.format("%m").to_string());
     result = result.replace("{day}", &now.format("%d").to_string());
+
+    // Text-based date tags (English, locale-independent)
+    result = result.replace("{monthName}", &now.format("%B").to_string());
+    result = result.replace("{monthShort}", &now.format("%b").to_string());
+    result = result.replace("{weekday}", &now.format("%A").to_string());
+    result = result.replace("{weekdayShort}", &now.format("%a").to_string());
+    let day_num = now.day();
+    result = result.replace(
+        "{dayOrdinal}",
+        &format!("{}{}", day_num, ordinal_suffix(day_num)),
+    );
 
     // Time tags (use dash instead of colon for filename safety)
     result = result.replace("{time}", &now.format("%H-%M-%S").to_string());

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -595,6 +595,16 @@ export function GeneralSettingsSection() {
                 <span>02</span>
                 <code>{"{day}"}</code>
                 <span>15</span>
+                <code>{"{monthName}"}</code>
+                <span>February</span>
+                <code>{"{monthShort}"}</code>
+                <span>Feb</span>
+                <code>{"{weekday}"}</code>
+                <span>Sunday</span>
+                <code>{"{weekdayShort}"}</code>
+                <span>Sun</span>
+                <code>{"{dayOrdinal}"}</code>
+                <span>15th</span>
                 <code>{"{counter}"}</code>
                 <span>1, 2, 3...</span>
               </div>


### PR DESCRIPTION
Usecase I found useful for readability when opening New Notes:

- Adds five human-readable date tokens to the default note name template: `{monthName}`, `{monthShort}`, `{weekday}`, `{weekdayShort}`, `{dayOrdinal}`.

- Lets users produce names like `Note-April-Sunday-19th` alongside the existing numeric `Note-{year}-{month}-{day}`.

<img width="828" height="561" alt="Screenshot 2026-04-19 at 10 42 33 p m" src="https://github.com/user-attachments/assets/ca3693e5-445b-4bab-a812-f0575cc11fde" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced note naming with additional template tags: `{monthName}`, `{monthShort}`, `{weekday}`, `{weekdayShort}`, and `{dayOrdinal}`. Users can now use human-readable date formats like "February", "Feb", "Sunday", "Sun", and "15th" in automatic note names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->