### PR TITLE
feat: allow changing or removing the git remote

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -405,7 +405,8 @@ pub fn add_remote(path: &Path, url: &str) -> GitResult {
 
 /// Update the URL of the existing 'origin' remote
 pub fn set_remote_url(path: &Path, url: &str) -> GitResult {
-    if !is_valid_remote_url(url) {
+    let normalized = url.trim();
+    if !is_valid_remote_url(normalized) {
         return GitResult {
             success: false,
             message: None,
@@ -414,7 +415,7 @@ pub fn set_remote_url(path: &Path, url: &str) -> GitResult {
     }
 
     let output = git_cmd()
-        .args(["remote", "set-url", "origin", url])
+        .args(["remote", "set-url", "origin", normalized])
         .current_dir(path)
         .output();
 
@@ -468,11 +469,12 @@ pub fn remove_remote(path: &Path) -> GitResult {
                 }
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                // Removing an already-missing 'origin' is idempotent — converge on "not connected".
                 if stderr.contains("No such remote") {
                     GitResult {
-                        success: false,
+                        success: true,
                         message: None,
-                        error: Some("No 'origin' remote configured".to_string()),
+                        error: None,
                     }
                 } else {
                     GitResult {

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -403,6 +403,94 @@ pub fn add_remote(path: &Path, url: &str) -> GitResult {
     }
 }
 
+/// Update the URL of the existing 'origin' remote
+pub fn set_remote_url(path: &Path, url: &str) -> GitResult {
+    if !is_valid_remote_url(url) {
+        return GitResult {
+            success: false,
+            message: None,
+            error: Some("Invalid remote URL format. URL must start with https://, http://, or git@".to_string()),
+        };
+    }
+
+    let output = git_cmd()
+        .args(["remote", "set-url", "origin", url])
+        .current_dir(path)
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                GitResult {
+                    success: true,
+                    message: Some("Remote URL updated".to_string()),
+                    error: None,
+                }
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                if stderr.contains("No such remote") {
+                    GitResult {
+                        success: false,
+                        message: None,
+                        error: Some("No 'origin' remote configured".to_string()),
+                    }
+                } else {
+                    GitResult {
+                        success: false,
+                        message: None,
+                        error: Some(stderr.trim().to_string()),
+                    }
+                }
+            }
+        }
+        Err(e) => GitResult {
+            success: false,
+            message: None,
+            error: Some(format!("Failed to update remote: {}", e)),
+        },
+    }
+}
+
+/// Remove the 'origin' remote
+pub fn remove_remote(path: &Path) -> GitResult {
+    let output = git_cmd()
+        .args(["remote", "remove", "origin"])
+        .current_dir(path)
+        .output();
+
+    match output {
+        Ok(output) => {
+            if output.status.success() {
+                GitResult {
+                    success: true,
+                    message: Some("Remote removed".to_string()),
+                    error: None,
+                }
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+                if stderr.contains("No such remote") {
+                    GitResult {
+                        success: false,
+                        message: None,
+                        error: Some("No 'origin' remote configured".to_string()),
+                    }
+                } else {
+                    GitResult {
+                        success: false,
+                        message: None,
+                        error: Some(stderr.trim().to_string()),
+                    }
+                }
+            }
+        }
+        Err(e) => GitResult {
+            success: false,
+            message: None,
+            error: Some(format!("Failed to remove remote: {}", e)),
+        },
+    }
+}
+
 /// Push to remote and set upstream tracking (git push -u origin <branch>)
 pub fn push_with_upstream(path: &Path, branch: &str) -> GitResult {
     let output = git_cmd()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2674,6 +2674,52 @@ async fn git_add_remote(url: String, state: State<'_, AppState>) -> Result<git::
 }
 
 #[tauri::command]
+async fn git_set_remote_url(url: String, state: State<'_, AppState>) -> Result<git::GitResult, String> {
+    let folder = {
+        let app_config = state.app_config.read().expect("app_config read lock");
+        app_config.notes_folder.clone()
+    };
+
+    match folder {
+        Some(path) => {
+            tauri::async_runtime::spawn_blocking(move || {
+                git::set_remote_url(&PathBuf::from(path), &url)
+            })
+            .await
+            .map_err(|e| e.to_string())
+        }
+        None => Ok(git::GitResult {
+            success: false,
+            message: None,
+            error: Some("Notes folder not set".to_string()),
+        }),
+    }
+}
+
+#[tauri::command]
+async fn git_remove_remote(state: State<'_, AppState>) -> Result<git::GitResult, String> {
+    let folder = {
+        let app_config = state.app_config.read().expect("app_config read lock");
+        app_config.notes_folder.clone()
+    };
+
+    match folder {
+        Some(path) => {
+            tauri::async_runtime::spawn_blocking(move || {
+                git::remove_remote(&PathBuf::from(path))
+            })
+            .await
+            .map_err(|e| e.to_string())
+        }
+        None => Ok(git::GitResult {
+            success: false,
+            message: None,
+            error: Some("Notes folder not set".to_string()),
+        }),
+    }
+}
+
+#[tauri::command]
 async fn git_push_with_upstream(state: State<'_, AppState>) -> Result<git::GitResult, String> {
     let folder = {
         let app_config = state.app_config.read().expect("app_config read lock");
@@ -3797,6 +3843,8 @@ pub fn run() {
             git_fetch,
             git_pull,
             git_add_remote,
+            git_set_remote_url,
+            git_remove_remote,
             git_push_with_upstream,
             ai_check_claude_cli,
             ai_check_codex_cli,

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -123,7 +123,7 @@ export const Footer = memo(function Footer({ onOpenSettings }: FooterProps) {
             <Button
               onClick={clearError}
               variant="link"
-              className="text-xs h-auto p-0 text-orange-500 hover:text-orange-600 hover:no-underline"
+              className="text-xs h-auto p-0 text-red-500 hover:text-red-600 hover:no-underline"
             >
               An error occurred
             </Button>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -110,8 +110,8 @@ export const Footer = memo(function Footer({ onOpenSettings }: FooterProps) {
           </Tooltip>
         ) : null}
 
-        {/* Changes indicator */}
-        {hasChanges && (
+        {/* Changes indicator — hidden when there's an error so we don't show a stale count alongside it */}
+        {hasChanges && !lastError && (
           <Tooltip content="You have uncommitted changes">
             <span className="text-xs text-text-muted/70">Files changed</span>
           </Tooltip>

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -587,43 +587,52 @@ export function GeneralSettingsSection() {
                 </div>
               )}
 
-              {/* Changes count */}
-              {status.changedCount > 0 && (
+              {/* Stats — hidden when status fetch errored, since counts may be stale or wrong */}
+              {status.error ? (
                 <div className="flex items-center justify-between pt-3 border-t border-border border-dashed">
-                  <span className="text-sm text-text font-medium">
-                    Changes to commit
-                  </span>
+                  <span className="text-sm text-text font-medium">Status</span>
                   <span className="text-sm text-text-muted">
-                    {status.changedCount} file
-                    {status.changedCount === 1 ? "" : "s"} changed
+                    An error occurred
                   </span>
                 </div>
-              )}
+              ) : (
+                <>
+                  {status.changedCount > 0 && (
+                    <div className="flex items-center justify-between pt-3 border-t border-border border-dashed">
+                      <span className="text-sm text-text font-medium">
+                        Changes to commit
+                      </span>
+                      <span className="text-sm text-text-muted">
+                        {status.changedCount} file
+                        {status.changedCount === 1 ? "" : "s"} changed
+                      </span>
+                    </div>
+                  )}
 
-              {/* Commits to push */}
-              {status.aheadCount > 0 && status.hasUpstream && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-text font-medium">
-                    Commits to push
-                  </span>
-                  <span className="text-sm text-text-muted">
-                    {status.aheadCount} commit
-                    {status.aheadCount === 1 ? "" : "s"}
-                  </span>
-                </div>
-              )}
+                  {status.aheadCount > 0 && status.hasUpstream && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-text font-medium">
+                        Commits to push
+                      </span>
+                      <span className="text-sm text-text-muted">
+                        {status.aheadCount} commit
+                        {status.aheadCount === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                  )}
 
-              {/* Commits to pull */}
-              {status.behindCount > 0 && status.hasUpstream && (
-                <div className="flex items-center justify-between">
-                  <span className="text-sm text-text font-medium">
-                    Commits to pull
-                  </span>
-                  <span className="text-sm text-text-muted">
-                    {status.behindCount} commit
-                    {status.behindCount === 1 ? "" : "s"}
-                  </span>
-                </div>
+                  {status.behindCount > 0 && status.hasUpstream && (
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-text font-medium">
+                        Commits to pull
+                      </span>
+                      <span className="text-sm text-text-muted">
+                        {status.behindCount} commit
+                        {status.behindCount === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                  )}
+                </>
               )}
 
               {/* Error display */}

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -639,7 +639,7 @@ export function GeneralSettingsSection() {
               {lastError && (
                 <div className="pt-3 border-t border-border">
                   <div className="bg-red-500/10 rounded-md p-3">
-                    <p className="text-sm text-red-500 capitalize">
+                    <p className="text-sm text-red-500 first-letter:capitalize">
                       {lastError}
                     </p>
                     {(lastError.includes("Authentication") ||

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -56,6 +56,8 @@ export function GeneralSettingsSection() {
     initRepo,
     isLoading,
     addRemote,
+    setRemoteUrl: updateRemoteUrl,
+    removeRemote,
     pushWithUpstream,
     isAddingRemote,
     isPushing,
@@ -65,6 +67,7 @@ export function GeneralSettingsSection() {
 
   const [remoteUrl, setRemoteUrl] = useState("");
   const [showRemoteInput, setShowRemoteInput] = useState(false);
+  const [isEditingRemote, setIsEditingRemote] = useState(false);
   const [noteTemplate, setNoteTemplate] = useState<string>("Untitled");
   const [previewNoteName, setPreviewNoteName] = useState<string>("Untitled");
   // Load template from settings on mount
@@ -177,6 +180,42 @@ export function GeneralSettingsSection() {
     }
   };
 
+  const handleStartEditRemote = () => {
+    setRemoteUrl(status?.remoteUrl || "");
+    setIsEditingRemote(true);
+    clearError();
+  };
+
+  const handleCancelEditRemote = () => {
+    setIsEditingRemote(false);
+    setRemoteUrl("");
+    clearError();
+  };
+
+  const handleSaveRemoteUrl = async () => {
+    if (isAddingRemote) return;
+    const trimmed = remoteUrl.trim();
+    if (!trimmed) return;
+    if (trimmed === status?.remoteUrl) {
+      setIsEditingRemote(false);
+      return;
+    }
+    const success = await updateRemoteUrl(trimmed);
+    if (success) {
+      setRemoteUrl("");
+      setIsEditingRemote(false);
+    }
+  };
+
+  const handleRemoveRemote = async () => {
+    if (isAddingRemote) return;
+    const success = await removeRemote();
+    if (success) {
+      setRemoteUrl("");
+      setIsEditingRemote(false);
+    }
+  };
+
   const handlePushWithUpstream = async () => {
     await pushWithUpstream();
   };
@@ -198,6 +237,7 @@ export function GeneralSettingsSection() {
 
     if (!enabled) {
       setShowRemoteInput(false);
+      setIsEditingRemote(false);
       setRemoteUrl("");
     }
   };
@@ -345,32 +385,98 @@ export function GeneralSettingsSection() {
               {/* Remote configuration */}
               {status.hasRemote ? (
                 <>
-                  <div className="flex items-center justify-between">
-                    <span className="text-sm text-text font-medium">
-                      Remote
-                    </span>
-                    {getRemoteWebUrl(status.remoteUrl) ? (
-                      <button
-                        onClick={() =>
-                          handleOpenUrl(getRemoteWebUrl(status.remoteUrl)!)
-                        }
-                        className="flex items-center gap-0.75 text-sm text-text-muted hover:text-text truncate max-w-50 transition-colors cursor-pointer"
-                        title={status.remoteUrl || undefined}
-                      >
-                        <span className="truncate">
-                          {formatRemoteUrl(status.remoteUrl)}
-                        </span>
-                        <ExternalLinkIcon className="w-3.25 h-3.25 shrink-0" />
-                      </button>
-                    ) : (
-                      <span
-                        className="text-sm text-text-muted truncate max-w-50"
-                        title={status.remoteUrl || undefined}
-                      >
-                        {formatRemoteUrl(status.remoteUrl)}
+                  {isEditingRemote ? (
+                    <div className="space-y-2">
+                      <span className="text-sm text-text font-medium">
+                        Remote
                       </span>
-                    )}
-                  </div>
+                      <Input
+                        type="text"
+                        value={remoteUrl}
+                        onChange={(e) => setRemoteUrl(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleSaveRemoteUrl();
+                          if (e.key === "Escape") handleCancelEditRemote();
+                        }}
+                        placeholder="https://github.com/user/repo.git"
+                        autoFocus
+                      />
+                      <div className="flex gap-2">
+                        <Button
+                          onClick={handleSaveRemoteUrl}
+                          disabled={
+                            isAddingRemote ||
+                            !remoteUrl.trim() ||
+                            remoteUrl.trim() === status.remoteUrl
+                          }
+                          size="sm"
+                        >
+                          {isAddingRemote ? (
+                            <>
+                              <SpinnerIcon className="w-3 h-3 mr-2 animate-spin" />
+                              Saving...
+                            </>
+                          ) : (
+                            "Save"
+                          )}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleCancelEditRemote}
+                          disabled={isAddingRemote}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleRemoveRemote}
+                          disabled={isAddingRemote}
+                          className="ml-auto text-red-500 hover:text-red-400 hover:bg-red-500/10"
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                      <RemoteInstructions />
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm text-text font-medium">
+                        Remote
+                      </span>
+                      <div className="flex items-center gap-2 min-w-0">
+                        {getRemoteWebUrl(status.remoteUrl) ? (
+                          <button
+                            onClick={() =>
+                              handleOpenUrl(getRemoteWebUrl(status.remoteUrl)!)
+                            }
+                            className="flex items-center gap-0.75 text-sm text-text-muted hover:text-text truncate max-w-50 transition-colors cursor-pointer"
+                            title={status.remoteUrl || undefined}
+                          >
+                            <span className="truncate">
+                              {formatRemoteUrl(status.remoteUrl)}
+                            </span>
+                            <ExternalLinkIcon className="w-3.25 h-3.25 shrink-0" />
+                          </button>
+                        ) : (
+                          <span
+                            className="text-sm text-text-muted truncate max-w-50"
+                            title={status.remoteUrl || undefined}
+                          >
+                            {formatRemoteUrl(status.remoteUrl)}
+                          </span>
+                        )}
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          onClick={handleStartEditRemote}
+                        >
+                          Change
+                        </Button>
+                      </div>
+                    </div>
+                  )}
 
                   {/* Upstream tracking status */}
                   {status.hasUpstream ? (

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -467,13 +467,13 @@ export function GeneralSettingsSection() {
                             {formatRemoteUrl(status.remoteUrl)}
                           </span>
                         )}
-                        <Button
-                          variant="ghost"
-                          size="xs"
+                        <button
+                          type="button"
                           onClick={handleStartEditRemote}
+                          className="text-sm text-text font-medium hover:text-text-muted transition-colors cursor-pointer"
                         >
                           Change
-                        </Button>
+                        </button>
                       </div>
                     </div>
                   )}
@@ -587,8 +587,8 @@ export function GeneralSettingsSection() {
                 </div>
               )}
 
-              {/* Stats — hidden when status fetch errored, since counts may be stale or wrong */}
-              {status.error ? (
+              {/* Stats — hidden whenever there's an error, since counts may be stale or misleading alongside it */}
+              {lastError ? (
                 <div className="flex items-center justify-between pt-3 border-t border-border border-dashed">
                   <span className="text-sm text-text font-medium">Status</span>
                   <span className="text-sm text-text-muted">
@@ -646,7 +646,7 @@ export function GeneralSettingsSection() {
                         href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-xs text-red-400 hover:text-red-300 underline mt-1 inline-block"
+                        className="text-xs text-red-500 hover:text-red-700 underline mt-1 inline-block"
                       >
                         Learn more about SSH authentication
                       </a>
@@ -654,7 +654,7 @@ export function GeneralSettingsSection() {
                     <Button
                       onClick={clearError}
                       variant="link"
-                      className="block text-xs h-auto p-0 mt-2 text-red-400 hover:text-red-300"
+                      className="block text-xs h-auto p-0 mt-2 text-red-500 hover:text-red-700"
                     >
                       Dismiss
                     </Button>
@@ -851,7 +851,9 @@ function IgnoredFoldersEditor() {
       try {
         await invoke("rebuild_search_index");
       } catch {
-        toast.error("Search index rebuild failed — search results may be stale");
+        toast.error(
+          "Search index rebuild failed — search results may be stale",
+        );
       }
     } catch {
       toast.error("Failed to save ignored folders");

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -433,7 +433,7 @@ export function GeneralSettingsSection() {
                           size="sm"
                           onClick={handleRemoveRemote}
                           disabled={isAddingRemote}
-                          className="ml-auto text-red-500 hover:text-red-400 hover:bg-red-500/10"
+                          className="ml-auto text-red-500 hover:text-red-600 hover:bg-red-500/10"
                         >
                           Remove
                         </Button>
@@ -528,7 +528,7 @@ export function GeneralSettingsSection() {
                     <span className="text-sm text-text font-medium">
                       Remote
                     </span>
-                    <span className="text-sm font-medium text-orange-500">
+                    <span className="text-sm font-medium text-red-500">
                       Not connected
                     </span>
                   </div>
@@ -638,15 +638,17 @@ export function GeneralSettingsSection() {
               {/* Error display */}
               {lastError && (
                 <div className="pt-3 border-t border-border">
-                  <div className="bg-red-500/10 border border-red-500/20 rounded-md p-3">
-                    <p className="text-sm text-red-500">{lastError}</p>
+                  <div className="bg-red-500/10 rounded-md p-3">
+                    <p className="text-sm text-red-500 capitalize">
+                      {lastError}
+                    </p>
                     {(lastError.includes("Authentication") ||
                       lastError.includes("SSH")) && (
                       <a
                         href="https://docs.github.com/en/authentication/connecting-to-github-with-ssh"
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-xs text-red-500 hover:text-red-700 underline mt-1 inline-block"
+                        className="text-sm text-red-500 hover:text-red-600 underline font-medium mt-1 inline-block"
                       >
                         Learn more about SSH authentication
                       </a>
@@ -654,7 +656,7 @@ export function GeneralSettingsSection() {
                     <Button
                       onClick={clearError}
                       variant="link"
-                      className="block text-xs h-auto p-0 mt-2 text-red-500 hover:text-red-700"
+                      className="block text-sm h-auto p-0 mt-2 text-red-500 hover:text-red-600 font-medium"
                     >
                       Dismiss
                     </Button>

--- a/src/context/GitContext.tsx
+++ b/src/context/GitContext.tsx
@@ -37,6 +37,8 @@ interface GitContextValue {
   pull: () => Promise<string | false>;
   sync: () => Promise<{ ok: true; message: string } | { ok: false; error: string }>;
   addRemote: (url: string) => Promise<boolean>;
+  setRemoteUrl: (url: string) => Promise<boolean>;
+  removeRemote: () => Promise<boolean>;
   pushWithUpstream: () => Promise<boolean>;
   clearError: () => void;
 }
@@ -273,6 +275,42 @@ export function GitProvider({ children }: { children: ReactNode }) {
     }
   }, [refreshStatus]);
 
+  const setRemoteUrl = useCallback(async (url: string) => {
+    setIsAddingRemote(true);
+    try {
+      const result = await gitService.setRemoteUrl(url);
+      if (result.error) {
+        setLastError(result.error);
+        return false;
+      }
+      await refreshStatus();
+      return true;
+    } catch (err) {
+      setLastError(err instanceof Error ? err.message : "Failed to update remote");
+      return false;
+    } finally {
+      setIsAddingRemote(false);
+    }
+  }, [refreshStatus]);
+
+  const removeRemote = useCallback(async () => {
+    setIsAddingRemote(true);
+    try {
+      const result = await gitService.removeRemote();
+      if (result.error) {
+        setLastError(result.error);
+        return false;
+      }
+      await refreshStatus();
+      return true;
+    } catch (err) {
+      setLastError(err instanceof Error ? err.message : "Failed to remove remote");
+      return false;
+    } finally {
+      setIsAddingRemote(false);
+    }
+  }, [refreshStatus]);
+
   const pushWithUpstream = useCallback(async () => {
     setIsPushing(true);
     try {
@@ -439,6 +477,8 @@ export function GitProvider({ children }: { children: ReactNode }) {
       pull,
       sync,
       addRemote,
+      setRemoteUrl,
+      removeRemote,
       pushWithUpstream,
       clearError,
     }),
@@ -462,6 +502,8 @@ export function GitProvider({ children }: { children: ReactNode }) {
       pull,
       sync,
       addRemote,
+      setRemoteUrl,
+      removeRemote,
       pushWithUpstream,
       clearError,
     ]

--- a/src/services/git.ts
+++ b/src/services/git.ts
@@ -50,6 +50,14 @@ export async function addRemote(url: string): Promise<GitResult> {
   return invoke("git_add_remote", { url });
 }
 
+export async function setRemoteUrl(url: string): Promise<GitResult> {
+  return invoke("git_set_remote_url", { url });
+}
+
+export async function removeRemote(): Promise<GitResult> {
+  return invoke("git_remove_remote");
+}
+
 export async function pushWithUpstream(): Promise<GitResult> {
   return invoke("git_push_with_upstream");
 }


### PR DESCRIPTION
## Summary
- Adds **Change** and **Remove** controls next to the configured remote in Version Control settings
- New Tauri commands `git_set_remote_url` (`git remote set-url origin <url>`) and `git_remove_remote` (`git remote remove origin`) — both preserve local history
- Fixes #147: a user who added the wrong remote URL can now fix it without disconnecting/reiniting the repo

## Behavior
- Display mode: "Change" button appears inline next to the remote URL
- Edit mode: input pre-filled with current URL; Save / Cancel / Remove buttons. Save is disabled when unchanged or empty. Enter saves, Escape cancels.

## Test plan
- [ ] Settings → Version Control with a remote configured shows "Change" next to the URL
- [ ] Clicking Change opens an input pre-filled with the current URL; editing + Save updates the remote (verify with `git remote -v`)
- [ ] Save is disabled when the URL is unchanged or empty
- [ ] Cancel / Escape exit edit mode without changes
- [ ] Remove deletes the origin remote and the UI returns to the "Not connected / Add Remote" state
- [ ] Invalid URL (e.g. `foo`) surfaces the validation error
- [ ] Tracking row hides correctly after remove (no stale `origin/<branch>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit and update the configured Git remote URL from Settings with an edit flow (Change → Save/Cancel).
  * Remove the configured Git remote from Settings; removal is idempotent if already absent.
  * Enter/Escape keyboard shortcuts and parsed remote link to open the web URL.

* **UI / Bug Fixes**
  * Status shows a single “Status / An error occurred” row when there’s an error and refreshes after remote changes.
  * Hide file-changed count in the footer when an error is present; error indicator styling updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->