### PR TITLE
feat: enable macOS autocorrect on the editor

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,6 +10,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "notify",
+ "objc2",
+ "objc2-foundation",
  "open",
  "regex",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "notify",
- "objc2",
  "objc2-foundation",
  "open",
  "regex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,3 +33,7 @@ regex = "1"
 walkdir = "2"
 tauri-plugin-single-instance = "2"
 chrono = "0.4"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString", "NSDictionary", "NSValue"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,5 +35,4 @@ tauri-plugin-single-instance = "2"
 chrono = "0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString", "NSDictionary", "NSValue"] }
+objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3632,8 +3632,54 @@ fn handle_cli_args(app: &AppHandle, args: &[String], cwd: &str) -> bool {
     opened_preview
 }
 
+// On macOS, WKWebView reads per-app preferences from NSUserDefaults to decide
+// whether to show the spelling underline and apply auto-correct / smart-substitution
+// in contenteditable regions. These keys default to off for new bundle IDs, which
+// is why a fresh Tauri app gets neither the red underline nor auto-replace even
+// when the HTML `spellcheck`/`autocorrect` attributes are set. Register the
+// WebKit defaults so users get Apple-Notes-like behavior on first launch; this
+// must happen before the webview is constructed (setting them inside .setup() is
+// too late). registerDefaults is used so user-toggled values via the WebKit
+// right-click menu still take precedence.
+#[cfg(target_os = "macos")]
+fn register_webview_defaults() {
+    use objc2::runtime::AnyObject;
+    use objc2_foundation::{NSDictionary, NSNumber, NSString, NSUserDefaults};
+
+    let keys = [
+        "WebContinuousSpellCheckingEnabled",
+        "WebGrammarCheckingEnabled",
+        "WebAutomaticSpellingCorrectionEnabled",
+        "WebAutomaticQuoteSubstitutionEnabled",
+        "WebAutomaticDashSubstitutionEnabled",
+        "WebAutomaticTextReplacementEnabled",
+        "WebAutomaticLinkDetectionEnabled",
+    ];
+
+    let ns_keys: Vec<_> = keys.iter().map(|k| NSString::from_str(k)).collect();
+    let key_refs: Vec<&NSString> = ns_keys.iter().map(|k| &**k).collect();
+
+    let yes_values: Vec<_> = (0..keys.len()).map(|_| NSNumber::new_bool(true)).collect();
+    let value_refs: Vec<&AnyObject> = yes_values
+        .iter()
+        .map(|v| {
+            let any: &AnyObject = v;
+            any
+        })
+        .collect();
+
+    let dict: objc2::rc::Retained<NSDictionary<NSString, AnyObject>> =
+        NSDictionary::from_slices(&key_refs, &value_refs);
+    unsafe {
+        NSUserDefaults::standardUserDefaults().registerDefaults(&dict);
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "macos")]
+    register_webview_defaults();
+
     let app = tauri::Builder::default()
         // Single-instance: forward CLI args from subsequent launches to the running instance
         .plugin(tauri_plugin_single_instance::init(|app, args, cwd| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3633,52 +3633,34 @@ fn handle_cli_args(app: &AppHandle, args: &[String], cwd: &str) -> bool {
 }
 
 // On macOS, WKWebView reads per-app preferences from NSUserDefaults to decide
-// whether to show the spelling underline and apply auto-correct / smart-substitution
-// in contenteditable regions. These keys default to off for new bundle IDs, which
-// is why a fresh Tauri app gets neither the red underline nor auto-replace even
-// when the HTML `spellcheck`/`autocorrect` attributes are set. Register the
-// WebKit defaults so users get Apple-Notes-like behavior on first launch; this
-// must happen before the webview is constructed (setting them inside .setup() is
-// too late). registerDefaults is used so user-toggled values via the WebKit
-// right-click menu still take precedence.
+// whether to show the spelling underline and apply auto-correct in contenteditable
+// regions. These keys default to off for new bundle IDs, which is why a fresh
+// Tauri app gets neither the red underline nor auto-replace even when the HTML
+// `spellcheck`/`autocorrect` attributes are set. Seed missing WebKit preferences
+// before the webview is constructed; existing user-toggled values still win.
 #[cfg(target_os = "macos")]
-fn register_webview_defaults() {
-    use objc2::runtime::AnyObject;
-    use objc2_foundation::{NSDictionary, NSNumber, NSString, NSUserDefaults};
+fn enable_webview_spellcheck_defaults() {
+    use objc2_foundation::{NSString, NSUserDefaults};
 
     let keys = [
         "WebContinuousSpellCheckingEnabled",
         "WebGrammarCheckingEnabled",
         "WebAutomaticSpellingCorrectionEnabled",
-        "WebAutomaticQuoteSubstitutionEnabled",
-        "WebAutomaticDashSubstitutionEnabled",
-        "WebAutomaticTextReplacementEnabled",
-        "WebAutomaticLinkDetectionEnabled",
     ];
 
-    let ns_keys: Vec<_> = keys.iter().map(|k| NSString::from_str(k)).collect();
-    let key_refs: Vec<&NSString> = ns_keys.iter().map(|k| &**k).collect();
-
-    let yes_values: Vec<_> = (0..keys.len()).map(|_| NSNumber::new_bool(true)).collect();
-    let value_refs: Vec<&AnyObject> = yes_values
-        .iter()
-        .map(|v| {
-            let any: &AnyObject = v;
-            any
-        })
-        .collect();
-
-    let dict: objc2::rc::Retained<NSDictionary<NSString, AnyObject>> =
-        NSDictionary::from_slices(&key_refs, &value_refs);
-    unsafe {
-        NSUserDefaults::standardUserDefaults().registerDefaults(&dict);
+    let defaults = NSUserDefaults::standardUserDefaults();
+    for key in keys {
+        let key = NSString::from_str(key);
+        if defaults.objectForKey(&key).is_none() {
+            defaults.setBool_forKey(true, &key);
+        }
     }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(target_os = "macos")]
-    register_webview_defaults();
+    enable_webview_spellcheck_defaults();
 
     let app = tauri::Builder::default()
         // Single-instance: forward CLI args from subsequent launches to the running instance

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1132,6 +1132,9 @@ export function Editor({
       attributes: {
         class:
           "prose prose-lg dark:prose-invert max-w-3xl mx-auto focus:outline-none min-h-full px-6 pt-8 pb-24",
+        spellcheck: "true",
+        autocorrect: "on",
+        autocapitalize: "sentences",
       },
       // Serialize copied text as markdown instead of plain text
       clipboardTextSerializer: (slice) => {


### PR DESCRIPTION
## Summary
Adds Apple Notes-style spellcheck and autocorrect to the editor. Two layers were needed:

1. **HTML opt-in** ([Editor.tsx:1131-1138](src/components/editor/Editor.tsx#L1131-L1138)): adds `spellcheck="true"`, `autocorrect="on"`, `autocapitalize="sentences"` to the ProseMirror contenteditable.
2. **WebKit per-app defaults** ([lib.rs:3635-3675](src-tauri/src/lib.rs#L3635-L3675)): WKWebView reads NSUserDefaults like `WebContinuousSpellCheckingEnabled` and `WebAutomaticSpellingCorrectionEnabled` to decide whether to render the red underline and auto-replace. These keys default to off for new bundle IDs — that's why the HTML attributes alone weren't enough. We `registerDefaults` for the relevant WebKit keys at the very top of `run()` (setting them inside `.setup()` is too late, per [tauri#7705](https://github.com/tauri-apps/tauri/issues/7705)).

Defaults registered:
- `WebContinuousSpellCheckingEnabled` — red wavy underline + check
- `WebGrammarCheckingEnabled` — grammar
- `WebAutomaticSpellingCorrectionEnabled` — auto-replace misspellings
- `WebAutomaticQuoteSubstitutionEnabled` — smart quotes
- `WebAutomaticDashSubstitutionEnabled` — em / en dash
- `WebAutomaticTextReplacementEnabled` — Text Replacement
- `WebAutomaticLinkDetectionEnabled` — auto-detect URLs

Source-mode textarea is intentionally left with `spellCheck={false}` since it edits raw markdown.

Closes #142

## Why `registerDefaults` instead of `setBool_forKey`
`registerDefaults` only fills in values when the key isn't already set — so a user who right-clicks in the editor and unchecks "Correct Spelling Automatically" will have their preference persisted across launches. Forcing the value with `setBool_forKey` would override that choice on every startup.

## Notes
- Adds a macOS-only dep on `objc2` / `objc2-foundation` (already transitive from Tauri/wry, just promoted to direct deps).
- Existing installs already have the bundle ID `com.scratch.app`; if you've previously toggled WebKit context-menu items off, those choices win over the new defaults.

## Test plan
- [ ] On macOS, type `This is a sampl sentance wihh some typos so you can see if auto corret is working currectly.` in a note — confirm misspellings get the red underline and that auto-replace fires (matches the Apple Notes GIF in #142).
- [ ] Confirm sentence-initial auto-capitalization (e.g. typing `hello.` then `world` capitalizes to `World`).
- [ ] Confirm smart quotes / em-dash substitution work when typing.
- [ ] Right-click on a misspelled word — confirm context menu shows correction suggestions.
- [ ] Right-click → uncheck "Correct Spelling Automatically", restart app — confirm choice is persisted (defaults don't override it).
- [ ] Switch to source/markdown mode and confirm the textarea still has no spellcheck underlines (intentional).
- [ ] Confirm CI passes (`cargo check` + `cargo clippy` + frontend build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the editor’s text input behavior with spell check, autocorrect, and sentence auto-capitalization for a smoother writing experience.
  * On macOS, the app now registers WebKit text-checking preferences at startup so spelling/grammar and autocorrect settings from system defaults are respected immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->