### PR TITLE
feat: add configurable paste mode

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -546,7 +546,7 @@ export function Editor({
   const pinNote = notesCtx?.pinNote;
   const unpinNote = notesCtx?.unpinNote;
   const notes = notesCtx?.notes;
-  const { textDirection } = useTheme();
+  const { textDirection, pasteMode } = useTheme();
   const [isSaving, setIsSaving] = useState(false);
   // Force re-render when selection changes to update toolbar active states
   const [, setSelectionKey] = useState(0);
@@ -1213,21 +1213,45 @@ export function Editor({
           }
         }
 
-        // Handle markdown text paste
         const text = clipboardData.getData("text/plain");
         if (!text) return false;
 
-        // Check if text looks like markdown (has common markdown patterns)
-        const markdownPatterns =
-          /^#{1,6}\s|^\s*[-*+]\s|^\s*\d+\.\s|^\s*>\s|```|^\s*\[.*\]\(.*\)|^\s*!\[|\*\*.*\*\*|__.*__|~~.*~~|^\s*[-*_]{3,}\s*$|^\|.+\||\$\$[\s\S]+?\$\$/m;
-        if (!markdownPatterns.test(text)) {
-          // Not markdown, let TipTap handle it normally
+        const currentEditor = editorRef.current;
+        if (!currentEditor) return false;
+
+        // Paste as plain text — strip all markdown formatting
+        if (pasteMode === "plain") {
+          currentEditor.commands.insertContent(
+            text.replace(/\r\n/g, "\n"),
+            { parseOptions: { preserveWhitespace: "full" } },
+          );
+          return true;
+        }
+
+        // Paste as code block wrapped in ``` ```
+        if (pasteMode === "code-block") {
+          const manager = currentEditor.storage.markdown?.manager;
+          if (manager && typeof manager.parse === "function") {
+            try {
+              const fenced = "```\n" + text + "\n```";
+              const parsed = manager.parse(fenced);
+              if (parsed) {
+                currentEditor.commands.insertContent(parsed);
+                return true;
+              }
+            } catch {
+              // fall through to default
+            }
+          }
           return false;
         }
 
-        // Parse markdown and insert using editor ref
-        const currentEditor = editorRef.current;
-        if (!currentEditor) return false;
+        // Default: "markdown" — detect and parse markdown patterns
+        const markdownPatterns =
+          /^#{1,6}\s|^\s*[-*+]\s|^\s*\d+\.\s|^\s*>\s|```|^\s*\[.*\]\(.*\)|^\s*!\[|\*\*.*\*\*|__.*__|~~.*~~|^\s*[-*_]{3,}\s*$|^\|.+\||\$\$[\s\S]+?\$\$/m;
+        if (!markdownPatterns.test(text)) {
+          return false;
+        }
 
         const manager = currentEditor.storage.markdown?.manager;
         if (manager && typeof manager.parse === "function") {

--- a/src/components/settings/EditorSettingsSection.tsx
+++ b/src/components/settings/EditorSettingsSection.tsx
@@ -6,6 +6,7 @@ import type {
   TextDirection,
   EditorWidth,
   ThemeColorKey,
+  PasteMode,
 } from "../../types/note";
 import { ChevronRightIcon, EyeIcon, MinusIcon, PlusIcon } from "../icons";
 import { cn } from "../../lib/utils";
@@ -48,6 +49,13 @@ const fontFamilyOptions: { value: FontFamily; label: string }[] = [
   { value: "monospace", label: "Mono" },
 ];
 
+// Paste mode options
+const pasteModeOptions: { value: PasteMode; label: string; description: string }[] = [
+  { value: "markdown", label: "Markdown", description: "Parse and render markdown syntax" },
+  { value: "plain", label: "Plain text", description: "Insert as plain text, no formatting" },
+  { value: "code-block", label: "Code block", description: "Wrap in a ``` code block" },
+];
+
 // Bold weight options (medium excluded for monospace)
 const boldWeightOptions = [
   { value: 500, label: "Medium", excludeForMonospace: true },
@@ -77,6 +85,8 @@ export function AppearanceSettingsSection() {
     setCustomColor,
     resetCustomColor,
     resetAllCustomColors,
+    pasteMode,
+    setPasteMode,
   } = useTheme();
 
   // Validated numeric change handler
@@ -456,6 +466,35 @@ export function AppearanceSettingsSection() {
           </div>
           {/* Fade overlay - content to muted background */}
           <div className="absolute bottom-0 left-0 right-0 h-40 bg-linear-to-t from-bg to-transparent pointer-events-none" />
+        </div>
+      </section>
+
+      {/* Divider */}
+      <div className="border-t border-border border-dashed" />
+
+      {/* Editing Section */}
+      <section className="pb-2">
+        <h2 className="text-xl font-medium mb-3">Editing</h2>
+        <div className="rounded-[10px] border border-border pl-4 py-3 pr-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-0.5">
+              <label className="text-sm text-text font-medium">Paste mode</label>
+              <span className="text-xs text-text-muted">
+                {pasteModeOptions.find((o) => o.value === pasteMode)?.description}
+              </span>
+            </div>
+            <Select
+              value={pasteMode}
+              onChange={(e) => setPasteMode(e.target.value as PasteMode)}
+              className="w-40"
+            >
+              {pasteModeOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </Select>
+          </div>
         </div>
       </section>
     </div>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -16,6 +16,7 @@ import type {
   EditorWidth,
   CustomColors,
   ThemeColorKey,
+  PasteMode,
 } from "../types/note";
 
 type ThemeMode = "light" | "dark" | "system";
@@ -117,6 +118,8 @@ interface ThemeContextType {
   setCustomColor: (mode: "light" | "dark", key: ThemeColorKey, value: string) => void;
   resetCustomColor: (mode: "light" | "dark", key: ThemeColorKey) => void;
   resetAllCustomColors: (mode: "light" | "dark") => void;
+  pasteMode: PasteMode;
+  setPasteMode: (mode: PasteMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextType | null>(null);
@@ -189,6 +192,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   );
   const [customColorsLight, setCustomColorsLightState] = useState<CustomColors>({});
   const [customColorsDark, setCustomColorsDarkState] = useState<CustomColors>({});
+  const [pasteMode, setPasteModeState] = useState<PasteMode>("markdown");
   const [isInitialized, setIsInitialized] = useState(false);
 
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">(() => {
@@ -247,6 +251,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       }
       if (settings.customColorsDark) {
         setCustomColorsDarkState(settings.customColorsDark);
+      }
+      if (
+        settings.pasteMode === "markdown" ||
+        settings.pasteMode === "plain" ||
+        settings.pasteMode === "code-block"
+      ) {
+        setPasteModeState(settings.pasteMode);
       }
     } catch {
       // If settings can't be loaded, use defaults
@@ -544,6 +555,16 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     [],
   );
 
+  const setPasteMode = useCallback(async (mode: PasteMode) => {
+    setPasteModeState(mode);
+    try {
+      const settings = await getSettings();
+      await updateSettings({ ...settings, pasteMode: mode });
+    } catch (error) {
+      console.error("Failed to save paste mode:", error);
+    }
+  }, []);
+
   // Live CSS variable update during drag (no persistence)
   const setEditorMaxWidthLive = useCallback((value: string) => {
     document.documentElement.style.setProperty("--editor-max-width", value);
@@ -579,6 +600,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         setCustomColor,
         resetCustomColor,
         resetAllCustomColors,
+        pasteMode,
+        setPasteMode,
       }}
     >
       {children}

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -20,6 +20,7 @@ export interface ThemeSettings {
 export type FontFamily = "system-sans" | "serif" | "monospace";
 export type TextDirection = "auto" | "ltr" | "rtl";
 export type EditorWidth = "narrow" | "normal" | "wide" | "full" | "custom";
+export type PasteMode = "markdown" | "plain" | "code-block";
 
 export interface EditorFontSettings {
   baseFontFamily?: FontFamily;
@@ -59,6 +60,7 @@ export interface Settings {
   ignoredPatterns?: string[];
   customColorsLight?: CustomColors;
   customColorsDark?: CustomColors;
+  pasteMode?: PasteMode;
 }
 
 export interface FolderNode {


### PR DESCRIPTION
## Summary

- Adds a **Paste mode** setting under **Settings → Appearance → Editing**
- Three options, persisted to `.scratch/settings.json`:
  - **Markdown** (default) — existing behavior: detects markdown patterns and renders them
  - **Plain text** — inserts pasted content as raw text, no formatting applied
  - **Code block** — wraps the pasted content in a fenced ` ``` ` code block

## Changes

- `src/types/note.ts` — adds `PasteMode` type and `pasteMode` field to `Settings`
- `src/context/ThemeContext.tsx` — loads, stores, and exposes `pasteMode` / `setPasteMode`
- `src/components/editor/Editor.tsx` — `handlePaste` branches on `pasteMode`
- `src/components/settings/EditorSettingsSection.tsx` — adds "Editing" section with a Select for paste mode

## Test plan

- [ ] Default behavior (Markdown mode) works as before — markdown in clipboard is rendered
- [ ] Plain text mode: paste markdown source, it appears as raw text
- [ ] Code block mode: paste any text, it is wrapped in a fenced code block
- [ ] Setting persists across app restarts
- [ ] Image paste still works in all modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable paste mode setting in editor preferences. Users can now choose between Markdown (default), Plain Text, and Code Block modes to control how pasted content is formatted and processed. Preferences are automatically saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->