### PR TITLE
fix: adapt in-app titlebar layout to the native Windows title bar

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -124,6 +124,12 @@ body,
   overscroll-behavior: none;
 }
 
+/* Windows keeps its native title bar (no in-app titlebar spacer); a top border
+   separates the app content from the themed caption. */
+.platform-windows #root {
+  border-top: 1px solid var(--color-border);
+}
+
 /* macOS transparent title bar support */
 .titlebar-drag-region {
   -webkit-app-region: drag;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import * as aiService from "./services/ai";
 import type { AiProvider } from "./services/ai";
+import { isMac, isWindows } from "./lib/platform";
 
 // Detect preview mode from URL search params
 function getWindowMode(): {
@@ -647,10 +648,8 @@ function App() {
 
   // Add platform class for OS-specific styling (e.g., keyboard shortcuts)
   useEffect(() => {
-    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
-    document.documentElement.classList.add(
-      isMac ? "platform-mac" : "platform-other",
-    );
+    const os = isMac ? "mac" : isWindows ? "windows" : "linux";
+    document.documentElement.classList.add(`platform-${os}`);
   }, []);
 
   // Check for app updates on startup (folder mode only)

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -37,7 +37,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { join } from "@tauri-apps/api/path";
 import { toast } from "sonner";
-import { mod, alt, shift, isMac } from "../../lib/platform";
+import { mod, alt, shift, isMac, isWindows } from "../../lib/platform";
 
 // Prepend https:// if no protocol is present
 function normalizeUrl(url: string): string {
@@ -2079,10 +2079,12 @@ export function Editor({
     if (previewMode) {
       return (
         <div className="flex-1 flex flex-col bg-bg">
-          <div
-            className="h-10 shrink-0 flex items-end px-4 pb-1"
-            data-tauri-drag-region
-          ></div>
+          {!isWindows && (
+            <div
+              className="h-10 shrink-0 flex items-end px-4 pb-1"
+              data-tauri-drag-region
+            ></div>
+          )}
           <div className="flex-1 flex items-center justify-center">
             <SpinnerIcon className="w-6 h-6 text-text-muted animate-spin" />
           </div>
@@ -2094,10 +2096,12 @@ export function Editor({
     if (notesCtx?.selectedNoteId) {
       return (
         <div className="flex-1 flex flex-col bg-bg">
-          <div
-            className="h-10 shrink-0 flex items-end px-4 pb-1"
-            data-tauri-drag-region
-          ></div>
+          {!isWindows && (
+            <div
+              className="h-10 shrink-0 flex items-end px-4 pb-1"
+              data-tauri-drag-region
+            ></div>
+          )}
           <div className="flex-1 flex items-center justify-center">
             <SpinnerIcon className="w-6 h-6 text-text-muted animate-spin" />
           </div>
@@ -2109,10 +2113,12 @@ export function Editor({
     return (
       <div className="flex-1 flex flex-col bg-bg">
         {/* Drag region */}
-        <div
-          className="h-10 shrink-0 flex items-end px-4 pb-1"
-          data-tauri-drag-region
-        ></div>
+        {!isWindows && (
+          <div
+            className="h-10 shrink-0 flex items-end px-4 pb-1"
+            data-tauri-drag-region
+          ></div>
+        )}
         <div className="flex-1 flex items-center justify-center pb-8">
           <div className="text-center text-text-muted select-none">
             <div
@@ -2163,7 +2169,7 @@ export function Editor({
       <div
         className={cn(
           "h-11 shrink-0 flex items-center justify-between px-3",
-          !isSidebarActive && "pl-22",
+          !isSidebarActive && !isWindows && "pl-22",
         )}
         data-tauri-drag-region
       >

--- a/src/components/layout/FolderPicker.tsx
+++ b/src/components/layout/FolderPicker.tsx
@@ -2,6 +2,7 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { useNotes } from "../../context/NotesContext";
 import { useTheme } from "../../context/ThemeContext";
 import { Button } from "../ui";
+import { isWindows } from "../../lib/platform";
 
 export function FolderPicker() {
   const { setNotesFolder } = useNotes();
@@ -28,7 +29,7 @@ export function FolderPicker() {
   return (
     <div className="h-full flex flex-col bg-bg-secondary">
       {/* Draggable title bar area */}
-      <div className="h-10 shrink-0" data-tauri-drag-region />
+      {!isWindows && <div className="h-10 shrink-0" data-tauri-drag-region />}
 
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center p-8 max-w-lg select-none">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
   FolderPlusIcon,
   NoteIcon,
 } from "../icons";
-import { mod, shift, isMac } from "../../lib/platform";
+import { mod, shift, isMac, isWindows } from "../../lib/platform";
 import * as notesService from "../../services/notes";
 import { FolderNameDialog } from "../notes/FolderNameDialog";
 
@@ -312,8 +312,8 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
     >
     <div className="relative w-64 h-full bg-bg-secondary border-r border-border flex flex-col select-none">
       {/* Drag region */}
-      <div className="h-11 shrink-0" data-tauri-drag-region></div>
-      <div className="flex items-center justify-between pl-4 pr-3 pb-2 border-b border-border shrink-0">
+      {!isWindows && <div className="h-11 shrink-0" data-tauri-drag-region></div>}
+      <div className={`flex items-center justify-between pl-4 pr-3 pb-2 border-b border-border shrink-0${isWindows ? " pt-2" : ""}`}>
         <div className="flex items-center gap-1">
           <div className="font-medium text-base">Notes</div>
           <div className="text-text-muted font-medium text-2xs min-w-4.75 h-4.75 flex items-center justify-center px-1 bg-bg-muted rounded-sm mt-0.5 pt-px">

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -13,7 +13,7 @@ import { AppearanceSettingsSection } from "./EditorSettingsSection";
 import { ShortcutsSettingsSection } from "./ShortcutsSettingsSection";
 import { AboutSettingsSection } from "./AboutSettingsSection";
 import { ToolsSettingsSection } from "./ToolsSettingsSection";
-import { mod, isMac } from "../../lib/platform";
+import { mod, isMac, isWindows } from "../../lib/platform";
 
 interface SettingsPageProps {
   onBack: () => void;
@@ -77,10 +77,10 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       {/* Sidebar - matches main Notes sidebar */}
       <div className="w-64 h-full bg-bg-secondary border-r border-border flex flex-col select-none">
         {/* Drag region */}
-        <div className="h-11 shrink-0" data-tauri-drag-region></div>
+        {!isWindows && <div className="h-11 shrink-0" data-tauri-drag-region></div>}
 
         {/* Header with back button and Settings title */}
-        <div className="flex items-center justify-between px-3 pb-2 border-b border-border shrink-0">
+        <div className={`flex items-center justify-between px-3 pb-2 border-b border-border shrink-0${isWindows ? " pt-2" : ""}`}>
           <div className="flex items-center gap-1">
             <IconButton
               onClick={onBack}
@@ -122,14 +122,14 @@ export function SettingsPage({ onBack }: SettingsPageProps) {
       {/* Main content area */}
       <div className="flex-1 flex flex-col bg-bg overflow-hidden">
         {/* Drag region */}
-        <div className="h-11 shrink-0" data-tauri-drag-region></div>
+        {!isWindows && <div className="h-11 shrink-0" data-tauri-drag-region></div>}
 
         {/* Content - centered with max width */}
         <div
           ref={scrollContainerRef}
           className="flex-1 overflow-auto scrollbar-gutter-stable"
         >
-          <div className="w-full max-w-3xl mx-auto px-6 pb-6">
+          <div className={`w-full max-w-3xl mx-auto px-6 pb-6${isWindows ? " pt-2" : ""}`}>
             {activeTab === "general" && <GeneralSettingsSection />}
             {activeTab === "tools" && <ToolsSettingsSection />}
             {activeTab === "editor" && <AppearanceSettingsSection />}

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -8,6 +8,9 @@ export const isMac =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 
+export const isWindows =
+  typeof navigator !== "undefined" && /Windows/.test(navigator.userAgent);
+
 /** Modifier key symbol/label */
 export const mod = isMac ? "⌘" : "Ctrl";
 export const alt = isMac ? "⌥" : "Alt";


### PR DESCRIPTION
The overlay drag strips (h-11/h-10) and the pl-22 traffic-light clearance exist only for the macOS overlay title bar. On Windows — which keeps a native, DWM-themed title bar (#136) — they left a dead gap above the content and a large empty gutter when the sidebar was collapsed.

- add an `isWindows` helper and a single `platform-<os>` class on <html>
- hide the overlay drag strips on Windows (kept on macOS/Linux)
- add a top border + small breathing padding under the native caption
- skip the pl-22 traffic-light clearance on Windows

<img width="986" height="644" alt="image" src="https://github.com/user-attachments/assets/9c28a208-b7ab-4f49-b55d-27c69d7362c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows compatibility with platform-specific layout optimizations and improved native title bar integration

* **Style**
  * Refined spacing, padding, and visual adjustments for improved appearance and consistency on Windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->