### PR TITLE
feat: edit a text selection with AI from the editor toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@tiptap/core": "^3.19.0",
+    "@tiptap/extension-code": "^3.18.0",
     "@tiptap/extension-code-block-lowlight": "^3.20.0",
     "@tiptap/extension-image": "^3.18.0",
     "@tiptap/extension-link": "^3.18.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,12 @@ pub struct AppConfig {
     pub notes_folder: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiPreset {
+    pub label: String,
+    pub instruction: String,
+}
+
 // Per-folder settings (stored in .scratch/settings.json within notes folder)
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {
@@ -124,6 +130,12 @@ pub struct Settings {
     pub custom_editor_width_px: Option<u32>,
     #[serde(rename = "ollamaModel")]
     pub ollama_model: Option<String>,
+    #[serde(rename = "opencodeModel")]
+    pub opencode_model: Option<String>,
+    #[serde(rename = "defaultAiProvider")]
+    pub default_ai_provider: Option<String>,
+    #[serde(rename = "aiSelectionPresets")]
+    pub ai_selection_presets: Option<Vec<AiPreset>>,
     #[serde(rename = "foldersEnabled")]
     pub folders_enabled: Option<bool>,
     #[serde(rename = "ignoredPatterns")]
@@ -3354,6 +3366,56 @@ async fn ai_check_ollama_cli() -> Result<bool, String> {
 }
 
 #[tauri::command]
+async fn ai_list_ollama_models() -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let path = get_expanded_path();
+        let output = no_window_cmd("ollama")
+            .env("PATH", &path)
+            .arg("list")
+            .output()
+            .map_err(|e| format!("Failed to run ollama list: {}", e))?;
+        if !output.status.success() {
+            return Err("Ollama is not running or returned an error.".to_string());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let models = stdout
+            .lines()
+            .skip(1)
+            .filter_map(|line| line.split_whitespace().next())
+            .map(|s| s.to_string())
+            .collect();
+        Ok(models)
+    })
+    .await
+    .map_err(|e| format!("Failed to list Ollama models: {}", e))?
+}
+
+#[tauri::command]
+async fn ai_list_opencode_models() -> Result<Vec<String>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let path = get_expanded_path();
+        let output = no_window_cmd("opencode")
+            .env("PATH", &path)
+            .arg("models")
+            .output()
+            .map_err(|e| format!("Failed to run opencode models: {}", e))?;
+        if !output.status.success() {
+            return Err("OpenCode failed to list models.".to_string());
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let models = stdout
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .map(|s| s.to_string())
+            .collect();
+        Ok(models)
+    })
+    .await
+    .map_err(|e| format!("Failed to list OpenCode models: {}", e))?
+}
+
+#[tauri::command]
 async fn ai_execute_ollama(
     file_path: String,
     prompt: String,
@@ -3492,6 +3554,106 @@ async fn ai_execute_ollama(
     } else {
         Ok(result)
     }
+}
+
+#[tauri::command]
+async fn ai_transform_text(
+    provider: String,
+    text: String,
+    prompt: String,
+    model: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<AiExecutionResult, String> {
+    let folder = {
+        let app_config = state.app_config.read().expect("app_config read lock");
+        app_config
+            .notes_folder
+            .clone()
+            .ok_or("Notes folder not set")?
+    };
+
+    let instructions = format!(
+        "You are a Markdown editor. Edit the Markdown in <text> as requested in \
+         <request>, and return ONLY the resulting Markdown, with no commentary, \
+         explanation, or code fences.\n\n\
+         <request>\n{prompt}\n</request>\n\n\
+         <text>\n{text}\n</text>\n\n\
+         Return only the edited Markdown."
+    );
+
+    let (cli_name, command, args, stdin, not_found, cwd, env) = match provider.as_str() {
+        "claude" => (
+            "Claude",
+            "claude",
+            vec!["--dangerously-skip-permissions".to_string(), "--print".to_string()],
+            instructions,
+            "Claude CLI not found. Please install it from https://claude.ai/code",
+            None,
+            None,
+        ),
+        "codex" => (
+            "Codex",
+            "codex",
+            vec![
+                "exec".to_string(),
+                "--skip-git-repo-check".to_string(),
+                "--dangerously-bypass-approvals-and-sandbox".to_string(),
+                "-".to_string(),
+            ],
+            instructions,
+            "Codex CLI not found. Please install it from https://github.com/openai/codex",
+            None,
+            None,
+        ),
+        "opencode" => {
+            let mut args = vec!["run".to_string()];
+            if let Some(m) = model.as_deref().map(str::trim).filter(|m| !m.is_empty()) {
+                args.push("--model".to_string());
+                args.push(m.to_string());
+            }
+            args.push("--".to_string());
+            args.push(instructions);
+            (
+                "OpenCode",
+                "opencode",
+                args,
+                String::new(),
+                "OpenCode CLI not found. Please install it from https://opencode.ai",
+                Some(folder),
+                Some(vec![(
+                    "OPENCODE_PERMISSION".to_string(),
+                    r#"{"*":"allow","bash":"deny","task":"deny","webfetch":"deny","websearch":"deny","codesearch":"deny","skill":"deny","external_directory":"deny","doom_loop":"deny"}"#.to_string(),
+                )]),
+            )
+        }
+        "ollama" => {
+            let model_name = match model {
+                Some(m) if !m.trim().is_empty() => m.trim().to_string(),
+                _ => "qwen3:8b".to_string(),
+            };
+            (
+                "Ollama",
+                "ollama",
+                vec!["run".to_string(), model_name],
+                instructions,
+                "Ollama CLI not found. Please install it from https://ollama.com",
+                None,
+                None,
+            )
+        }
+        other => return Err(format!("Unknown AI provider: {}", other)),
+    };
+
+    execute_ai_cli(
+        cli_name,
+        command.to_string(),
+        args,
+        stdin,
+        not_found.to_string(),
+        cwd,
+        env,
+    )
+    .await
 }
 
 /// Check if a markdown file is inside the configured notes folder.
@@ -3850,10 +4012,13 @@ pub fn run() {
             ai_check_codex_cli,
             ai_check_opencode_cli,
             ai_check_ollama_cli,
+            ai_list_ollama_models,
+            ai_list_opencode_models,
             ai_execute_claude,
             ai_execute_codex,
             ai_execute_opencode,
             ai_execute_ollama,
+            ai_transform_text,
             read_file_direct,
             save_file_direct,
             import_file_to_folder,

--- a/src/App.css
+++ b/src/App.css
@@ -278,11 +278,40 @@ html.dark {
   animation: pulse-gentle 1.3s ease-in-out infinite;
 }
 
+@keyframes text-shimmer {
+  from {
+    background-position: 200% center;
+  }
+  to {
+    background-position: -200% center;
+  }
+}
+
+.text-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--color-text-muted) 35%,
+    var(--color-text) 50%,
+    var(--color-text-muted) 65%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: text-shimmer 2.2s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .animate-spin-slow,
   .animate-bounce-gentle,
   .animate-pulse-gentle {
     animation: none;
+  }
+  .text-shimmer {
+    animation: none;
+    color: var(--color-text-muted);
+    -webkit-text-fill-color: var(--color-text-muted);
   }
 }
 

--- a/src/components/ai/AiSelectionModal.tsx
+++ b/src/components/ai/AiSelectionModal.tsx
@@ -1,0 +1,257 @@
+import { useState, useRef, useEffect, type KeyboardEvent } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  SpinnerIcon,
+  ClaudeIcon,
+  CodexIcon,
+  OpenCodeIcon,
+  OllamaIcon,
+} from "../icons";
+import {
+  aiTransformSelection,
+  getAvailableAiProviders,
+  type AiProvider,
+} from "../../services/ai";
+import type { Settings } from "../../types/note";
+import { DEFAULT_AI_PRESETS, type AiPreset } from "./presets";
+
+interface AiSelectionModalProps {
+  open: boolean;
+  selectedText: string;
+  onClose: () => void;
+  onApply: (text: string) => void;
+}
+
+function stripThinking(text: string): string {
+  return text
+    .replace(/<think>[\s\S]*?<\/think>/gi, "")
+    .replace(/Thinking\.\.\.[\s\S]*?\.\.\.done thinking\./gi, "")
+    .trim();
+}
+
+export function AiSelectionModal({
+  open,
+  selectedText,
+  onClose,
+  onApply,
+}: AiSelectionModalProps) {
+  const [provider, setProvider] = useState<AiProvider | null>(null);
+  const [loadingProviders, setLoadingProviders] = useState(true);
+  const [model, setModel] = useState<string>("");
+  const [guidance, setGuidance] = useState("");
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [presets, setPresets] = useState<AiPreset[]>(DEFAULT_AI_PRESETS);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const ProviderIcon =
+    provider === "codex"
+      ? CodexIcon
+      : provider === "opencode"
+        ? OpenCodeIcon
+        : provider === "ollama"
+          ? OllamaIcon
+          : ClaudeIcon;
+  const providerName =
+    provider === "codex"
+      ? "Codex"
+      : provider === "opencode"
+        ? "OpenCode"
+        : provider === "ollama"
+          ? "Ollama"
+          : "Claude";
+
+  useEffect(() => {
+    if (!open) return;
+    setLoadingProviders(true);
+    Promise.all([getAvailableAiProviders(), invoke<Settings>("get_settings")])
+      .then(([providers, settings]) => {
+        const preferred = settings.defaultAiProvider;
+        setProvider(
+          preferred && providers.includes(preferred)
+            ? preferred
+            : (providers[0] ?? null),
+        );
+        setPresets(
+          settings.aiSelectionPresets?.length
+            ? settings.aiSelectionPresets
+            : DEFAULT_AI_PRESETS,
+        );
+      })
+      .catch(() => setProvider(null))
+      .finally(() => setLoadingProviders(false));
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    invoke<Settings>("get_settings")
+      .then((settings) => {
+        if (provider === "ollama")
+          setModel(settings.ollamaModel || "qwen3:8b");
+        else if (provider === "opencode")
+          setModel(settings.opencodeModel || "");
+        else setModel("");
+      })
+      .catch(() => {});
+  }, [open, provider]);
+
+  useEffect(() => {
+    if (!open) {
+      setGuidance("");
+      setError(null);
+      return;
+    }
+    const focus = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(focus);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEscape = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [open, onClose]);
+
+  const run = async (instruction: string) => {
+    const trimmed = instruction.trim();
+    if (!provider || isRunning || !trimmed) return;
+
+    setError(null);
+    setIsRunning(true);
+    try {
+      const result = await aiTransformSelection(
+        provider,
+        selectedText,
+        trimmed,
+        model || undefined,
+      );
+      if (result.success) {
+        const cleaned = stripThinking(result.output);
+        if (cleaned) {
+          onApply(cleaned);
+        } else {
+          setError("The AI returned an empty result.");
+        }
+      } else {
+        setError(result.error || "The AI request failed. Please try again.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "The AI request failed.");
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      run(guidance);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-text/50 backdrop-blur-sm z-40 animate-fade-in"
+        onClick={onClose}
+      />
+      <div className="fixed inset-0 z-50 flex items-center justify-center py-11 px-4 pointer-events-none">
+        <div className="relative w-full max-w-2xl bg-bg rounded-xl shadow-2xl overflow-hidden border border-border animate-slide-down pointer-events-auto">
+          <div className="border-b border-border">
+            <div className="flex items-center gap-3 px-4.5 py-3.5">
+              <ProviderIcon className="w-5 h-5 text-text-muted" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={guidance}
+                onChange={(e) => {
+                  setGuidance(e.target.value);
+                  setError(null);
+                }}
+                onKeyDown={handleKeyDown}
+                placeholder="Tell the AI how to edit the selection..."
+                disabled={isRunning || (!loadingProviders && !provider)}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck={false}
+                className="flex-1 text-[17px] bg-transparent outline-none text-text placeholder-text-muted/50 disabled:opacity-50"
+              />
+            </div>
+          </div>
+
+          <div className="p-4.5 space-y-3">
+            {loadingProviders ? (
+              <div className="flex items-center gap-2 text-sm text-text-muted">
+                <SpinnerIcon className="w-4 h-4 animate-spin" />
+                <span>Detecting AI providers...</span>
+              </div>
+            ) : !provider ? (
+              <div className="text-sm p-3 bg-orange-500/10 rounded-md text-orange-700 dark:text-orange-400">
+                No AI provider installed. Add one from Settings to use this
+                feature.
+              </div>
+            ) : isRunning ? (
+              <div className="py-1">
+                <span className="text-shimmer text-sm font-medium">
+                  {providerName} is editing your selection...
+                </span>
+              </div>
+            ) : (
+              <>
+                {error && (
+                  <div className="text-sm p-3 bg-red-500/10 rounded-md text-red-500">
+                    {error}
+                  </div>
+                )}
+                <div className="flex flex-wrap gap-1.5">
+                  {presets
+                    .filter((p) => p.label.trim() && p.instruction.trim())
+                    .map((preset, i) => (
+                      <button
+                        key={`${preset.label}-${i}`}
+                        onClick={() => {
+                          setGuidance(preset.instruction);
+                          run(preset.instruction);
+                        }}
+                        disabled={isRunning}
+                        className="px-2.5 py-1 text-sm rounded-md bg-bg-muted text-text hover:bg-bg-emphasis disabled:opacity-50 transition-colors"
+                      >
+                        {preset.label}
+                      </button>
+                    ))}
+                </div>
+
+                <div className="text-sm text-text-muted line-clamp-3 p-3 bg-bg-muted rounded-md">
+                  {selectedText}
+                </div>
+
+                <div className="w-full flex justify-between">
+                  <div className="flex items-center gap-1.5 text-sm text-text-muted">
+                    <kbd className="text-xs px-1.5 py-0.5 rounded-md bg-bg-muted text-text-muted">
+                      Esc
+                    </kbd>
+                    <span>to close</span>
+                  </div>
+                  <div className="flex items-center gap-1.5 text-sm text-text-muted">
+                    <kbd className="text-xs px-1.5 py-0.5 rounded-md bg-bg-muted text-text-muted">
+                      Enter
+                    </kbd>
+                    <span>to submit</span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/ai/presets.ts
+++ b/src/components/ai/presets.ts
@@ -1,0 +1,22 @@
+export interface AiPreset {
+  label: string;
+  instruction: string;
+}
+
+export const DEFAULT_AI_PRESETS: AiPreset[] = [
+  {
+    label: "Fix grammar",
+    instruction:
+      "Fix spelling and grammar mistakes. Keep the meaning, tone, and language; change only what is incorrect.",
+  },
+  {
+    label: "Summarize",
+    instruction:
+      "Summarize this into a concise version, keeping the key points and the original language.",
+  },
+  {
+    label: "Rephrase",
+    instruction:
+      "Rephrase to improve clarity and flow while preserving the meaning and the original language.",
+  },
+];

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -21,6 +21,7 @@ import TaskItem from "@tiptap/extension-task-item";
 import { TableKit } from "@tiptap/extension-table";
 import { Markdown } from "@tiptap/markdown";
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight";
+import { Code } from "@tiptap/extension-code";
 import { lowlight } from "./lowlight";
 import { CodeBlockView } from "./CodeBlockView";
 import { Extension, InputRule } from "@tiptap/core";
@@ -1067,7 +1068,9 @@ export function Editor({
           levels: [1, 2, 3, 4, 5, 6],
         },
         codeBlock: false,
+        code: false,
       }),
+      Code.extend({ excludes: "" }),
       CodeBlockLowlight.extend({
         addNodeView() {
           return ReactNodeViewRenderer(CodeBlockView);

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -107,7 +107,9 @@ import {
   MarkdownIcon,
   MarkdownOffIcon,
   FolderPlusIcon,
+  SparklesIcon,
 } from "../icons";
+import { AiSelectionModal } from "../ai/AiSelectionModal";
 
 function formatDateTime(timestamp: number): string {
   const date = new Date(timestamp * 1000);
@@ -246,6 +248,7 @@ interface FormatBarProps {
   onAddLink: () => void;
   onAddBlockMath: () => void;
   onAddImage: () => void;
+  onAskAi: () => void;
 }
 
 // FormatBar must re-render with parent to reflect editor.isActive() state changes
@@ -255,6 +258,7 @@ function FormatBar({
   onAddLink,
   onAddBlockMath,
   onAddImage,
+  onAskAi,
 }: FormatBarProps) {
   const [tableMenuOpen, setTableMenuOpen] = useState(false);
 
@@ -423,6 +427,18 @@ function FormatBar({
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
       </DropdownMenu.Root>
+
+      <div className="w-px h-4.5 border-l border-border mx-2" />
+
+      <ToolbarButton
+        onClick={onAskAi}
+        isActive={false}
+        disabled={editor.state.selection.empty}
+        title="Ask AI"
+        className="disabled:opacity-40"
+      >
+        <SparklesIcon className="w-4.5 h-4.5 stroke-[1.5]" />
+      </ToolbarButton>
     </div>
   );
 }
@@ -1552,6 +1568,35 @@ export function Editor({
   }, []); // Only run cleanup on unmount, not when saveNote changes
 
   // Link handlers - show inline popup at cursor position
+  const [aiSelection, setAiSelection] = useState<{
+    from: number;
+    to: number;
+    text: string;
+  } | null>(null);
+
+  const handleAskAi = useCallback(() => {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    if (from === to) return;
+    const text = editor.state.doc.textBetween(from, to, "\n");
+    if (text.trim()) setAiSelection({ from, to, text });
+  }, [editor]);
+
+  const applyAiSelection = useCallback(
+    (result: string) => {
+      if (!editor || !aiSelection) return;
+      const manager = editor.storage.markdown?.manager;
+      const parsed = manager ? manager.parse(result) : result;
+      editor
+        .chain()
+        .focus()
+        .insertContentAt({ from: aiSelection.from, to: aiSelection.to }, parsed)
+        .run();
+      setAiSelection(null);
+    },
+    [editor, aiSelection],
+  );
+
   const handleAddLink = useCallback(() => {
     if (!editor) return;
 
@@ -2367,8 +2412,16 @@ export function Editor({
           onAddLink={handleAddLink}
           onAddBlockMath={handleAddBlockMath}
           onAddImage={handleAddImage}
+          onAskAi={handleAskAi}
         />
       </div>
+
+      <AiSelectionModal
+        open={!!aiSelection}
+        selectedText={aiSelection?.text ?? ""}
+        onClose={() => setAiSelection(null)}
+        onApply={applyAiSelection}
+      />
 
       {/* Editor content area with resize handles overlay */}
       <div data-editor-content-area className="flex-1 relative overflow-hidden">

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -5,6 +5,19 @@ interface IconProps {
   className?: string;
 }
 
+export function GripVerticalIcon({ className = "w-4.5 h-4.5" }: IconProps) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <circle cx="9" cy="5" r="1.4" />
+      <circle cx="9" cy="12" r="1.4" />
+      <circle cx="9" cy="19" r="1.4" />
+      <circle cx="15" cy="5" r="1.4" />
+      <circle cx="15" cy="12" r="1.4" />
+      <circle cx="15" cy="19" r="1.4" />
+    </svg>
+  );
+}
+
 export function PilcrowIcon({ className = "w-4.5 h-4.5" }: IconProps) {
   return (
     <svg
@@ -72,6 +85,26 @@ export function XIcon({ className = "w-4.5 h-4.5" }: IconProps) {
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />
       <path d="M18 6l-12 12" />
       <path d="M6 6l12 12" />
+    </svg>
+  );
+}
+
+export function SparklesIcon({ className = "w-4.5 h-4.5" }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z" />
+      <path d="M20 3v4" />
+      <path d="M22 5h-4" />
+      <path d="M4 17v2" />
+      <path d="M5 18H3" />
     </svg>
   );
 }

--- a/src/components/settings/QuickActionsEditor.tsx
+++ b/src/components/settings/QuickActionsEditor.tsx
@@ -1,0 +1,301 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVerticalIcon, TrashIcon, PlusIcon } from "../icons";
+import type { Settings } from "../../types/note";
+import { DEFAULT_AI_PRESETS } from "../ai/presets";
+
+interface Item {
+  id: string;
+  label: string;
+  instruction: string;
+}
+
+interface Draft {
+  id: string;
+  label: string;
+  instruction: string;
+  isNew: boolean;
+}
+
+function newId() {
+  return crypto.randomUUID();
+}
+
+interface FormProps {
+  draft: Draft;
+  onChange: (field: "label" | "instruction", value: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  onDelete?: () => void;
+}
+
+function PresetForm({ draft, onChange, onCancel, onSave, onDelete }: FormProps) {
+  const valid = draft.label.trim() && draft.instruction.trim();
+  return (
+    <div className="p-4 rounded-[10px] border border-text/30 bg-bg space-y-3">
+      <input
+        autoFocus
+        value={draft.label}
+        onChange={(e) => onChange("label", e.target.value)}
+        placeholder="Action name"
+        className="w-full text-[15px] font-semibold bg-transparent outline-none text-text placeholder-text-muted/50"
+      />
+      <div>
+        <div className="text-2xs font-semibold uppercase tracking-wide text-text-muted mb-1.5">
+          Prompt sent to the model
+        </div>
+        <textarea
+          value={draft.instruction}
+          onChange={(e) => onChange("instruction", e.target.value)}
+          placeholder="Describe what the AI should do with the selected text…"
+          rows={3}
+          className="w-full text-sm bg-bg-muted rounded-md px-3 py-2 outline-none text-text placeholder-text-muted/50 border border-border focus:border-text-muted resize-none transition-colors"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs text-text-muted">
+          The selected text is appended automatically.
+        </span>
+        <div className="flex items-center gap-2 shrink-0">
+          {!draft.isNew && onDelete && (
+            <button
+              onClick={onDelete}
+              title="Delete"
+              className="p-1.5 text-text-muted hover:text-red-500 transition-colors"
+            >
+              <TrashIcon className="w-4 h-4 stroke-[1.6]" />
+            </button>
+          )}
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 text-sm rounded-lg border border-border hover:bg-bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onSave}
+            disabled={!valid}
+            className="px-3 py-1.5 text-sm font-medium rounded-lg bg-text text-bg hover:opacity-90 disabled:opacity-40 disabled:cursor-not-allowed transition-opacity"
+          >
+            {draft.isNew ? "Add action" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface RowProps {
+  item: Item;
+  draft: Draft | null;
+  onEdit: () => void;
+  onChange: (field: "label" | "instruction", value: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  onDelete: () => void;
+}
+
+function SortableRow({
+  item,
+  draft,
+  onEdit,
+  onChange,
+  onCancel,
+  onSave,
+  onDelete,
+}: RowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: item.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      {draft ? (
+        <PresetForm
+          draft={draft}
+          onChange={onChange}
+          onCancel={onCancel}
+          onSave={onSave}
+          onDelete={onDelete}
+        />
+      ) : (
+        <div className="flex items-start gap-2 p-3 rounded-[10px] border border-border bg-bg">
+          <button
+            {...attributes}
+            {...listeners}
+            title="Drag to reorder"
+            className="mt-0.5 shrink-0 cursor-grab touch-none text-text-muted/40 hover:text-text-muted"
+          >
+            <GripVerticalIcon className="w-4 h-4" />
+          </button>
+          <button onClick={onEdit} className="flex-1 min-w-0 text-left">
+            <div className="text-sm font-medium truncate">
+              {item.label || "Untitled action"}
+            </div>
+            <div className="text-xs text-text-muted truncate">
+              {item.instruction || "No instruction yet"}
+            </div>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function QuickActionsEditor() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [editing, setEditing] = useState<Draft | null>(null);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  useEffect(() => {
+    invoke<Settings>("get_settings")
+      .then((s) => {
+        const presets = s.aiSelectionPresets?.length
+          ? s.aiSelectionPresets
+          : DEFAULT_AI_PRESETS;
+        setItems(presets.map((p) => ({ id: newId(), ...p })));
+      })
+      .catch(() =>
+        setItems(DEFAULT_AI_PRESETS.map((p) => ({ id: newId(), ...p }))),
+      );
+  }, []);
+
+  const persist = (next: Item[]) => {
+    const presets = next.map(({ label, instruction }) => ({
+      label,
+      instruction,
+    }));
+    invoke<Settings>("get_settings")
+      .then((s) =>
+        invoke("update_settings", {
+          newSettings: { ...s, aiSelectionPresets: presets },
+        }),
+      )
+      .catch(() => {});
+  };
+
+  const changeDraft = (field: "label" | "instruction", value: string) =>
+    setEditing((d) => (d ? { ...d, [field]: value } : d));
+
+  const save = () => {
+    if (!editing) return;
+    const label = editing.label.trim();
+    const instruction = editing.instruction.trim();
+    if (!label || !instruction) return;
+    const entry = { id: editing.id, label, instruction };
+    setItems((prev) => {
+      const next = editing.isNew
+        ? [...prev, entry]
+        : prev.map((it) => (it.id === entry.id ? entry : it));
+      persist(next);
+      return next;
+    });
+    setEditing(null);
+  };
+
+  const remove = (id: string) => {
+    setItems((prev) => {
+      const next = prev.filter((it) => it.id !== id);
+      persist(next);
+      return next;
+    });
+    setEditing(null);
+  };
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setItems((prev) => {
+      const next = arrayMove(
+        prev,
+        prev.findIndex((it) => it.id === active.id),
+        prev.findIndex((it) => it.id === over.id),
+      );
+      persist(next);
+      return next;
+    });
+  };
+
+  return (
+    <div>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={onDragEnd}
+      >
+        <SortableContext
+          items={items.map((it) => it.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div className="space-y-2">
+            {items.map((it) => (
+              <SortableRow
+                key={it.id}
+                item={it}
+                draft={
+                  editing && !editing.isNew && editing.id === it.id
+                    ? editing
+                    : null
+                }
+                onEdit={() =>
+                  setEditing({
+                    id: it.id,
+                    label: it.label,
+                    instruction: it.instruction,
+                    isNew: false,
+                  })
+                }
+                onChange={changeDraft}
+                onCancel={() => setEditing(null)}
+                onSave={save}
+                onDelete={() => remove(it.id)}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      {editing?.isNew ? (
+        <div className="mt-2.5">
+          <PresetForm
+            draft={editing}
+            onChange={changeDraft}
+            onCancel={() => setEditing(null)}
+            onSave={save}
+          />
+        </div>
+      ) : (
+        <button
+          onClick={() =>
+            setEditing({ id: newId(), label: "", instruction: "", isNew: true })
+          }
+          className="mt-2.5 w-full flex items-center justify-center gap-1.5 py-2.5 text-sm text-text-muted hover:text-text border border-dashed border-border rounded-[10px] hover:bg-bg-muted transition-colors"
+        >
+          <PlusIcon className="w-4 h-4 stroke-[1.6]" />
+          New quick action
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/settings/ToolsSettingsSection.tsx
+++ b/src/components/settings/ToolsSettingsSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useReducer } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { toast } from "sonner";
-import { Button } from "../ui";
+import { Button, Select } from "../ui";
 import {
   SpinnerIcon,
   CheckIcon,
@@ -15,6 +15,8 @@ import * as aiService from "../../services/ai";
 import { mod } from "../../lib/platform";
 import * as cliService from "../../services/cli";
 import type { CliStatus } from "../../services/cli";
+import type { Settings } from "../../types/note";
+import { QuickActionsEditor } from "./QuickActionsEditor";
 
 type CliState = {
   status: CliStatus | null;
@@ -68,27 +70,37 @@ const AI_PROVIDER_INFO: Record<
   AiProvider,
   {
     name: string;
+    vendor: string;
+    blurb: string;
     icon: React.ComponentType<{ className?: string }>;
     installUrl: string;
   }
 > = {
   claude: {
     name: "Claude Code",
+    vendor: "Anthropic",
+    blurb: "Anthropic's coding agent in your terminal.",
     icon: ClaudeIcon,
     installUrl: "https://code.claude.com/docs/en/quickstart",
   },
   codex: {
     name: "OpenAI Codex",
+    vendor: "OpenAI",
+    blurb: "OpenAI's coding agent in your terminal.",
     icon: CodexIcon,
     installUrl: "https://github.com/openai/codex",
   },
   opencode: {
     name: "OpenCode",
+    vendor: "opencode.ai",
+    blurb: "Open-source terminal coding agent.",
     icon: OpenCodeIcon,
     installUrl: "https://opencode.ai",
   },
   ollama: {
     name: "Ollama",
+    vendor: "Local",
+    blurb: "Run open models locally, fully offline.",
     icon: OllamaIcon,
     installUrl: "https://ollama.com",
   },
@@ -98,6 +110,13 @@ export function ToolsSettingsSection() {
   const [cli, dispatchCli] = useReducer(cliReducer, cliInitialState);
   const [aiProviders, setAiProviders] = useState<AiProvider[]>([]);
   const [aiProvidersLoading, setAiProvidersLoading] = useState(true);
+  const [defaultProvider, setDefaultProvider] = useState<AiProvider | null>(
+    null,
+  );
+  const [ollamaModel, setOllamaModel] = useState("qwen3:8b");
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [opencodeModel, setOpencodeModel] = useState("");
+  const [opencodeModels, setOpencodeModels] = useState<string[]>([]);
 
   useEffect(() => {
     cliService
@@ -116,6 +135,60 @@ export function ToolsSettingsSection() {
       .catch(() => setAiProviders([]))
       .finally(() => setAiProvidersLoading(false));
   }, []);
+
+  useEffect(() => {
+    invoke<Settings>("get_settings")
+      .then((s) => {
+        setDefaultProvider(s.defaultAiProvider ?? null);
+        setOllamaModel(s.ollamaModel || "qwen3:8b");
+        setOpencodeModel(s.opencodeModel || "");
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    aiService
+      .listOllamaModels()
+      .then(setOllamaModels)
+      .catch(() => setOllamaModels([]));
+    aiService
+      .listOpencodeModels()
+      .then(setOpencodeModels)
+      .catch(() => setOpencodeModels([]));
+  }, []);
+
+  const handleSetDefault = (provider: AiProvider) => {
+    setDefaultProvider(provider);
+    invoke<Settings>("get_settings")
+      .then((s) =>
+        invoke("update_settings", {
+          newSettings: { ...s, defaultAiProvider: provider },
+        }),
+      )
+      .catch(() => {});
+  };
+
+  const handleSetOllamaModel = (model: string) => {
+    setOllamaModel(model);
+    invoke<Settings>("get_settings")
+      .then((s) =>
+        invoke("update_settings", {
+          newSettings: { ...s, ollamaModel: model },
+        }),
+      )
+      .catch(() => {});
+  };
+
+  const handleSetOpencodeModel = (model: string) => {
+    setOpencodeModel(model);
+    invoke<Settings>("get_settings")
+      .then((s) =>
+        invoke("update_settings", {
+          newSettings: { ...s, opencodeModel: model },
+        }),
+      )
+      .catch(() => {});
+  };
 
   const handleInstallCli = async () => {
     dispatchCli({ type: "operating" });
@@ -155,8 +228,8 @@ export function ToolsSettingsSection() {
       <section className="pb-2">
         <h2 className="text-xl font-medium mb-0.5">AI Providers</h2>
         <p className="text-sm text-text-muted mb-4">
-          Edit notes with AI from the command palette ({mod}P while editing a
-          note)
+          Pick a provider to make it your default for AI editing ({mod}P in a
+          note, or on a selection). Each one keeps its own model.
         </p>
 
         {aiProvidersLoading ? (
@@ -167,41 +240,150 @@ export function ToolsSettingsSection() {
             </span>
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="grid grid-cols-2 gap-3">
             {AI_PROVIDER_ORDER.map((provider) => {
               const installed = aiProviders.includes(provider);
               const info = AI_PROVIDER_INFO[provider];
-              return (
-                <div
-                  key={provider}
-                  className="flex items-center justify-between p-3 rounded-[10px] border border-border"
-                >
-                  <div className="flex items-center gap-2.5">
-                    <info.icon className="w-4.5 h-4.5 text-text-muted" />
-                    <span className="text-sm font-medium">{info.name}</span>
-                  </div>
-                  {installed ? (
-                    <span className="flex items-center gap-1.25 text-sm text-text-muted">
-                      Installed
-                      <span className="h-4.5 w-4.5 bg-bg-emphasis rounded-full flex items-center justify-center">
-                        <CheckIcon className="w-3 h-3 stroke-[2.2]" />
+
+              if (!installed) {
+                return (
+                  <div
+                    key={provider}
+                    className="flex flex-col gap-3 p-4 rounded-xl border border-dashed border-border bg-bg-secondary min-h-33"
+                  >
+                    <div className="flex items-center gap-2.5">
+                      <span className="w-9 h-9 rounded-[10px] grid place-items-center bg-bg-muted text-text-muted shrink-0">
+                        <info.icon className="w-5 h-5" />
                       </span>
-                    </span>
-                  ) : (
+                      <div className="flex flex-col min-w-0">
+                        <span className="text-sm font-semibold truncate">
+                          {info.name}
+                        </span>
+                        <span className="text-xs text-text-muted">
+                          {info.vendor}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="text-xs text-text-muted flex-1 m-0">
+                      {info.blurb}
+                    </p>
                     <a
                       href={info.installUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-sm text-text font-medium hover:text-text-muted transition-colors cursor-pointer"
+                      className="self-start text-xs font-medium px-3 py-1.5 rounded-lg border border-border hover:bg-bg-muted transition-colors"
                     >
                       Install
                     </a>
-                  )}
+                  </div>
+                );
+              }
+
+              const isDefault =
+                (defaultProvider ?? aiProviders[0]) === provider;
+              const modelSel =
+                provider === "ollama"
+                  ? {
+                      value: ollamaModel,
+                      options: ollamaModels,
+                      onChange: handleSetOllamaModel,
+                    }
+                  : provider === "opencode"
+                    ? {
+                        value: opencodeModel,
+                        options: opencodeModels,
+                        onChange: handleSetOpencodeModel,
+                      }
+                    : null;
+
+              return (
+                <div
+                  key={provider}
+                  onClick={() => handleSetDefault(provider)}
+                  className={`flex flex-col gap-3 p-4 rounded-xl border cursor-pointer transition-all min-h-33 ${
+                    isDefault
+                      ? "border-text/30 bg-bg-muted shadow-lg"
+                      : "border-border hover:border-text-muted/50"
+                  }`}
+                >
+                  <div className="flex items-start gap-2.5">
+                    <span className="w-10 h-10 rounded-[11px] grid place-items-center bg-bg border border-border text-text-muted shrink-0">
+                      <info.icon className="w-5.5 h-5.5" />
+                    </span>
+                    <div className="flex flex-col flex-1 min-w-0">
+                      <span className="text-sm font-semibold truncate">
+                        {info.name}
+                      </span>
+                      <span className="text-xs text-text-muted">
+                        {info.vendor}
+                      </span>
+                    </div>
+                    <span
+                      className={`w-5.5 h-5.5 rounded-full grid place-items-center shrink-0 transition-all ${
+                        isDefault
+                          ? "bg-text text-text-inverse"
+                          : "border-[1.5px] border-border"
+                      }`}
+                    >
+                      {isDefault && (
+                        <CheckIcon className="w-3 h-3 stroke-[2.5]" />
+                      )}
+                    </span>
+                  </div>
+                  <div className="mt-auto flex items-center justify-between gap-2">
+                    {modelSel ? (
+                      <>
+                        <span className="text-2xs font-semibold uppercase tracking-wide text-text-muted shrink-0">
+                          Model
+                        </span>
+                        <div
+                          className="flex-1 min-w-0"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Select
+                            value={modelSel.value}
+                            onChange={(e) =>
+                              modelSel.onChange(e.target.value)
+                            }
+                          >
+                            {!modelSel.value && (
+                              <option value="">Default model</option>
+                            )}
+                            {Array.from(
+                              new Set(
+                                [modelSel.value, ...modelSel.options].filter(
+                                  Boolean,
+                                ),
+                              ),
+                            ).map((m) => (
+                              <option key={m} value={m}>
+                                {m}
+                              </option>
+                            ))}
+                          </Select>
+                        </div>
+                      </>
+                    ) : (
+                      <span className="text-xs text-text-muted">
+                        Model set in the CLI
+                      </span>
+                    )}
+                  </div>
                 </div>
               );
             })}
           </div>
         )}
+      </section>
+
+      {/* AI quick actions */}
+      <section className="pb-2">
+        <h2 className="text-xl font-medium mb-0.5">Quick actions</h2>
+        <p className="text-sm text-text-muted mb-4">
+          One-click presets shown when editing a selection with AI.
+        </p>
+
+        <QuickActionsEditor />
       </section>
 
       {/* CLI Tool (macOS only) */}

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -80,3 +80,20 @@ export async function executeOllamaEdit(
 ): Promise<AiExecutionResult> {
   return invoke("ai_execute_ollama", { filePath, prompt, model });
 }
+
+export async function listOllamaModels(): Promise<string[]> {
+  return invoke("ai_list_ollama_models");
+}
+
+export async function listOpencodeModels(): Promise<string[]> {
+  return invoke("ai_list_opencode_models");
+}
+
+export async function aiTransformSelection(
+  provider: AiProvider,
+  text: string,
+  prompt: string,
+  model?: string,
+): Promise<AiExecutionResult> {
+  return invoke("ai_transform_text", { provider, text, prompt, model });
+}

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -56,6 +56,9 @@ export interface Settings {
   defaultNoteName?: string;
   interfaceZoom?: number;
   ollamaModel?: string;
+  opencodeModel?: string;
+  defaultAiProvider?: "claude" | "codex" | "opencode" | "ollama";
+  aiSelectionPresets?: { label: string; instruction: string }[];
   ignoredPatterns?: string[];
   customColorsLight?: CustomColors;
   customColorsDark?: CustomColors;


### PR DESCRIPTION
Adds a wand button to the editor toolbar that sends the selected text to an AI provider and replaces the selection inline. Addresses the per-selection editing part of #37 (the diff/review part is tracked separately in #56).

- New `ai_transform_text` command: transforms a snippet through the existing provider CLIs and returns the edited text (no whole-note rewrite). Reasoning model "thinking" output is stripped before applying.

<img width="1260" height="628" alt="image" src="https://github.com/user-attachments/assets/904aba04-dabf-48f8-b621-b813d6d04edb" />

- AiSelectionModal: customizable one-click presets plus a free instruction, an animated status while running, and in-modal errors.
- Settings (Integrations): selectable provider cards to choose the default, per-provider model selection for Ollama and OpenCode (listed via their CLIs), and an editable, reorderable list of quick actions.

<img width="1239" height="1003" alt="image" src="https://github.com/user-attachments/assets/9f73e7f7-2c9d-4a96-bb7a-88e658c4f29e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Ask AI" editor button and modal to transform selected text with presets (Fix grammar, Summarize, Rephrase)
  * Support for multiple AI providers with configurable default provider and per-provider model selection
  * AI quick-actions editor with drag-and-drop reordering and editable presets
  * Settings UI updated to manage AI providers and model selection

* **Style**
  * New text-shimmer animation and motion-reduction handling

* **New Icons**
  * Added Sparkles and GripVertical icons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->