### PR TITLE
feat: drag-to-resize sidebar width

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,7 @@ pub struct Settings {
     pub interface_zoom: Option<f32>,
     #[serde(rename = "customEditorWidthPx")]
     pub custom_editor_width_px: Option<u32>,
+    /// Custom sidebar width in px; `None` means the default width is used.
     #[serde(rename = "sidebarWidthPx")]
     pub sidebar_width_px: Option<u32>,
     #[serde(rename = "ollamaModel")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,8 @@ pub struct Settings {
     pub interface_zoom: Option<f32>,
     #[serde(rename = "customEditorWidthPx")]
     pub custom_editor_width_px: Option<u32>,
+    #[serde(rename = "sidebarWidthPx")]
+    pub sidebar_width_px: Option<u32>,
     #[serde(rename = "ollamaModel")]
     pub ollama_model: Option<String>,
     #[serde(rename = "foldersEnabled")]

--- a/src/App.css
+++ b/src/App.css
@@ -1054,6 +1054,11 @@ table.not-prose th {
   transition: none !important;
 }
 
+/* Suppress sidebar transition during drag resize */
+.sidebar-no-transition [data-sidebar] {
+  transition: none !important;
+}
+
 /* Print styles for clean PDF export */
 @page {
   margin: 0.75in;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { listen } from "@tauri-apps/api/event";
 import { GitProvider } from "./context/GitContext";
 import { TooltipProvider, Toaster } from "./components/ui";
 import { Sidebar } from "./components/layout/Sidebar";
+import { SidebarResizeHandle } from "./components/layout/SidebarResizeHandle";
 import { Editor } from "./components/editor/Editor";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import { FolderPicker } from "./components/layout/FolderPicker";
@@ -472,9 +473,11 @@ function AppContent() {
           <>
             <div
               data-sidebar
-              className={`transition-all duration-500 ease-out overflow-hidden ${!sidebarVisible || focusMode ? "opacity-0 -translate-x-4 w-0 pointer-events-none" : "opacity-100 translate-x-0 w-64"}`}
+              style={{ width: (!sidebarVisible || focusMode) ? 0 : "var(--sidebar-width, 16rem)" }}
+              className={`relative transition-all duration-500 ease-out overflow-hidden ${!sidebarVisible || focusMode ? "opacity-0 -translate-x-4 pointer-events-none" : "opacity-100 translate-x-0"}`}
             >
               <Sidebar onOpenSettings={toggleSettings} />
+              {sidebarVisible && !focusMode && <SidebarResizeHandle />}
             </div>
             <Editor
               onToggleSidebar={toggleSidebar}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { GitProvider } from "./context/GitContext";
 import { TooltipProvider, Toaster } from "./components/ui";
 import { Sidebar } from "./components/layout/Sidebar";
 import { SidebarResizeHandle } from "./components/layout/SidebarResizeHandle";
+import { SIDEBAR_DEFAULT_PX } from "./lib/sidebar";
 import { Editor } from "./components/editor/Editor";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import { FolderPicker } from "./components/layout/FolderPicker";
@@ -473,7 +474,7 @@ function AppContent() {
           <>
             <div
               data-sidebar
-              style={{ width: (!sidebarVisible || focusMode) ? 0 : "var(--sidebar-width, 16rem)" }}
+              style={{ width: (!sidebarVisible || focusMode) ? 0 : `var(--sidebar-width, ${SIDEBAR_DEFAULT_PX}px)` }}
               className={`relative transition-all duration-500 ease-out overflow-hidden ${!sidebarVisible || focusMode ? "opacity-0 -translate-x-4 pointer-events-none" : "opacity-100 translate-x-0"}`}
             >
               <Sidebar onOpenSettings={toggleSettings} />

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -310,7 +310,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
       onDragEnd={handleDragEnd}
       onDragCancel={() => setDragLabel(null)}
     >
-    <div className="relative w-64 h-full bg-bg-secondary border-r border-border flex flex-col select-none">
+    <div className="relative w-full h-full bg-bg-secondary border-r border-border flex flex-col select-none">
       {/* Drag region */}
       <div className="h-11 shrink-0" data-tauri-drag-region></div>
       <div className="flex items-center justify-between pl-4 pr-3 pb-2 border-b border-border shrink-0">

--- a/src/components/layout/SidebarResizeHandle.tsx
+++ b/src/components/layout/SidebarResizeHandle.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useRef, useState } from "react";
+import { useTheme } from "../../context/ThemeContext";
+import { cn } from "../../lib/utils";
+import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../../lib/sidebar";
+
+export function SidebarResizeHandle() {
+  const { sidebarWidthPx, setSidebarWidthPx, setSidebarWidthLive } = useTheme();
+
+  const [isDragging, setIsDragging] = useState(false);
+  const [currentWidth, setCurrentWidth] = useState(0);
+
+  const dragState = useRef<{
+    startX: number;
+    initialWidth: number;
+  } | null>(null);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      (e.currentTarget as HTMLElement).focus();
+
+      const initialWidth =
+        sidebarWidthPx ?? (e.currentTarget as HTMLElement).parentElement!.offsetWidth;
+      dragState.current = {
+        startX: e.clientX,
+        initialWidth,
+      };
+      setIsDragging(true);
+      setCurrentWidth(initialWidth);
+      document.documentElement.classList.add("sidebar-no-transition");
+    },
+    [sidebarWidthPx],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragState.current) return;
+      const { startX, initialWidth } = dragState.current;
+
+      const delta = e.clientX - startX;
+      const newWidth = initialWidth + delta;
+      const clamped = Math.round(
+        Math.min(Math.max(newWidth, SIDEBAR_MIN_PX), SIDEBAR_MAX_PX),
+      );
+
+      setSidebarWidthLive(clamped);
+      setCurrentWidth(clamped);
+    },
+    [setSidebarWidthLive],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragState.current) return;
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+      document.documentElement.classList.remove("sidebar-no-transition");
+
+      setSidebarWidthPx(currentWidth);
+      dragState.current = null;
+      setIsDragging(false);
+    },
+    [currentWidth, setSidebarWidthPx],
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    if (!dragState.current) return;
+    document.documentElement.classList.remove("sidebar-no-transition");
+    dragState.current = null;
+    setIsDragging(false);
+  }, []);
+
+  const handleDoubleClick = useCallback(() => {
+    document.documentElement.classList.remove("sidebar-no-transition");
+    setSidebarWidthPx(null);
+  }, [setSidebarWidthPx]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const step = e.shiftKey ? 64 : 16;
+      const base =
+        sidebarWidthPx ?? (e.currentTarget as HTMLElement).parentElement!.offsetWidth;
+      let next: number | null = null;
+
+      switch (e.key) {
+        case "ArrowLeft":
+          next = base - step;
+          break;
+        case "ArrowRight":
+          next = base + step;
+          break;
+        case "Home":
+          next = SIDEBAR_MIN_PX;
+          break;
+        case "End":
+          next = SIDEBAR_MAX_PX;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      setSidebarWidthPx(next);
+    },
+    [sidebarWidthPx, setSidebarWidthPx],
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize sidebar width"
+      aria-valuenow={sidebarWidthPx ?? undefined}
+      aria-valuemin={SIDEBAR_MIN_PX}
+      aria-valuemax={SIDEBAR_MAX_PX}
+      tabIndex={0}
+      className={cn(
+        "absolute top-0 right-0 h-full w-1.5 cursor-col-resize pointer-events-auto group outline-none",
+        isDragging && "z-20",
+      )}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onDoubleClick={handleDoubleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className={cn(
+          "absolute left-1/2 -translate-x-1/2 top-0 h-full w-0.75 rounded-full bg-border transition-opacity duration-150",
+          isDragging
+            ? "opacity-100"
+            : "opacity-0 group-hover:opacity-100 group-focus:opacity-100",
+        )}
+      />
+      {isDragging && (
+        <div className="absolute top-3 right-2 z-50">
+          <div className="bg-text text-text-inverse text-xs font-medium px-2.5 py-1 rounded-md shadow-lg whitespace-nowrap">
+            {Math.round(currentWidth)}px
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/SidebarResizeHandle.tsx
+++ b/src/components/layout/SidebarResizeHandle.tsx
@@ -3,6 +3,10 @@ import { useTheme } from "../../context/ThemeContext";
 import { cn } from "../../lib/utils";
 import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../../lib/sidebar";
 
+/**
+ * Drag handle rendered on the right edge of the sidebar.
+ * Supports pointer drag to resize, keyboard arrow keys (Shift = large step), and double-click to reset width.
+ */
 export function SidebarResizeHandle() {
   const { sidebarWidthPx, setSidebarWidthPx, setSidebarWidthLive } = useTheme();
 
@@ -14,6 +18,7 @@ export function SidebarResizeHandle() {
     initialWidth: number;
   } | null>(null);
 
+  /** Captures the pointer and records the drag start position and initial width. */
   const handlePointerDown = useCallback(
     (e: React.PointerEvent) => {
       e.preventDefault();
@@ -34,6 +39,7 @@ export function SidebarResizeHandle() {
     [sidebarWidthPx],
   );
 
+  /** Updates the CSS variable live during drag without persisting. */
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
       if (!dragState.current) return;
@@ -51,6 +57,7 @@ export function SidebarResizeHandle() {
     [setSidebarWidthLive],
   );
 
+  /** Releases pointer capture and persists the final width to settings. */
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
       if (!dragState.current) return;
@@ -64,6 +71,7 @@ export function SidebarResizeHandle() {
     [currentWidth, setSidebarWidthPx],
   );
 
+  /** Aborts the drag on pointer cancel without saving any width change. */
   const handlePointerCancel = useCallback(() => {
     if (!dragState.current) return;
     document.documentElement.classList.remove("sidebar-no-transition");
@@ -71,11 +79,13 @@ export function SidebarResizeHandle() {
     setIsDragging(false);
   }, []);
 
+  /** Resets the sidebar to its default width (removes the override). */
   const handleDoubleClick = useCallback(() => {
     document.documentElement.classList.remove("sidebar-no-transition");
     setSidebarWidthPx(null);
   }, [setSidebarWidthPx]);
 
+  /** Adjusts width with arrow keys (16 px step, 64 px with Shift); Home/End jump to bounds. */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       const step = e.shiftKey ? 64 : 16;

--- a/src/components/layout/SidebarResizeHandle.tsx
+++ b/src/components/layout/SidebarResizeHandle.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "../../context/ThemeContext";
 import { cn } from "../../lib/utils";
-import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../../lib/sidebar";
+import { SIDEBAR_DEFAULT_PX, SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../../lib/sidebar";
 
 /** Pointer movement below this many px counts as a click, not a drag. */
 const DRAG_THRESHOLD_PX = 3;
@@ -122,7 +122,6 @@ export function SidebarResizeHandle() {
 
   /** Resets the sidebar to its default width (removes the override). */
   const handleDoubleClick = useCallback(() => {
-    document.documentElement.classList.remove("sidebar-no-transition");
     setSidebarWidthPx(null);
   }, [setSidebarWidthPx]);
 
@@ -162,7 +161,7 @@ export function SidebarResizeHandle() {
       role="separator"
       aria-orientation="vertical"
       aria-label="Resize sidebar width"
-      aria-valuenow={sidebarWidthPx ?? undefined}
+      aria-valuenow={sidebarWidthPx ?? SIDEBAR_DEFAULT_PX}
       aria-valuemin={SIDEBAR_MIN_PX}
       aria-valuemax={SIDEBAR_MAX_PX}
       tabIndex={0}
@@ -182,7 +181,7 @@ export function SidebarResizeHandle() {
           "absolute left-1/2 -translate-x-1/2 top-0 h-full w-0.75 rounded-full bg-border transition-opacity duration-150",
           isDragging
             ? "opacity-100"
-            : "opacity-0 group-hover:opacity-100 group-focus:opacity-100",
+            : "opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100",
         )}
       />
       {isDragging && (

--- a/src/components/layout/SidebarResizeHandle.tsx
+++ b/src/components/layout/SidebarResizeHandle.tsx
@@ -1,7 +1,19 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTheme } from "../../context/ThemeContext";
 import { cn } from "../../lib/utils";
 import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../../lib/sidebar";
+
+/** Pointer movement below this many px counts as a click, not a drag. */
+const DRAG_THRESHOLD_PX = 3;
+
+/** Applies the `--sidebar-width` override; `null` falls back to the CSS default. */
+function applyWidthVar(px: number | null) {
+  if (px === null) {
+    document.documentElement.style.removeProperty("--sidebar-width");
+  } else {
+    document.documentElement.style.setProperty("--sidebar-width", `${px}px`);
+  }
+}
 
 /**
  * Drag handle rendered on the right edge of the sidebar.
@@ -16,7 +28,26 @@ export function SidebarResizeHandle() {
   const dragState = useRef<{
     startX: number;
     initialWidth: number;
+    moved: boolean;
   } | null>(null);
+
+  // Latest persisted width, readable from the unmount cleanup below
+  const persistedWidthRef = useRef(sidebarWidthPx);
+  useEffect(() => {
+    persistedWidthRef.current = sidebarWidthPx;
+  }, [sidebarWidthPx]);
+
+  // If unmounted mid-drag (e.g. focus mode toggled via shortcut), restore the
+  // transition class and the persisted width so the live drag value doesn't stick
+  useEffect(
+    () => () => {
+      if (dragState.current) {
+        document.documentElement.classList.remove("sidebar-no-transition");
+        applyWidthVar(persistedWidthRef.current);
+      }
+    },
+    [],
+  );
 
   /** Captures the pointer and records the drag start position and initial width. */
   const handlePointerDown = useCallback(
@@ -31,6 +62,7 @@ export function SidebarResizeHandle() {
       dragState.current = {
         startX: e.clientX,
         initialWidth,
+        moved: false,
       };
       setIsDragging(true);
       setCurrentWidth(initialWidth);
@@ -43,9 +75,12 @@ export function SidebarResizeHandle() {
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
       if (!dragState.current) return;
-      const { startX, initialWidth } = dragState.current;
+      const { startX, initialWidth, moved } = dragState.current;
 
       const delta = e.clientX - startX;
+      if (!moved && Math.abs(delta) < DRAG_THRESHOLD_PX) return;
+      dragState.current.moved = true;
+
       const newWidth = initialWidth + delta;
       const clamped = Math.round(
         Math.min(Math.max(newWidth, SIDEBAR_MIN_PX), SIDEBAR_MAX_PX),
@@ -61,23 +96,29 @@ export function SidebarResizeHandle() {
   const handlePointerUp = useCallback(
     (e: React.PointerEvent) => {
       if (!dragState.current) return;
+      const { moved } = dragState.current;
       (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
       document.documentElement.classList.remove("sidebar-no-transition");
 
-      setSidebarWidthPx(currentWidth);
+      // A stationary click must not persist: the two clicks of a double-click
+      // reset would otherwise issue settings writes that race the reset itself
+      if (moved) {
+        setSidebarWidthPx(currentWidth);
+      }
       dragState.current = null;
       setIsDragging(false);
     },
     [currentWidth, setSidebarWidthPx],
   );
 
-  /** Aborts the drag on pointer cancel without saving any width change. */
+  /** Aborts the drag on pointer cancel, restoring the last persisted width. */
   const handlePointerCancel = useCallback(() => {
     if (!dragState.current) return;
     document.documentElement.classList.remove("sidebar-no-transition");
+    applyWidthVar(sidebarWidthPx);
     dragState.current = null;
     setIsDragging(false);
-  }, []);
+  }, [sidebarWidthPx]);
 
   /** Resets the sidebar to its default width (removes the override). */
   const handleDoubleClick = useCallback(() => {

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -484,7 +484,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   }, []);
 
-  // Set sidebar width in px (persists to settings). Pass null to reset to default 16rem.
+  /**
+   * Persists the clamped sidebar width to settings.
+   * Pass `null` to remove the override and fall back to the CSS default.
+   */
   const setSidebarWidthPx = useCallback(async (px: number | null) => {
     if (px === null) {
       setSidebarWidthPxState(null);
@@ -595,7 +598,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     document.documentElement.style.setProperty("--editor-max-width", value);
   }, []);
 
-  // Live sidebar width update during drag (no persistence)
+  /** Updates `--sidebar-width` CSS variable immediately during drag without writing to settings. */
   const setSidebarWidthLive = useCallback((px: number) => {
     document.documentElement.style.setProperty("--sidebar-width", `${px}px`);
   }, []);

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -491,7 +491,6 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const setSidebarWidthPx = useCallback(async (px: number | null) => {
     if (px === null) {
       setSidebarWidthPxState(null);
-      document.documentElement.style.removeProperty("--sidebar-width");
       try {
         const settings = await getSettings();
         await updateSettings({ ...settings, sidebarWidthPx: undefined });

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getSettings, updateSettings } from "../services/notes";
+import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../lib/sidebar";
 import type {
   ThemeSettings,
   EditorFontSettings,
@@ -112,6 +113,9 @@ interface ThemeContextType {
   customEditorWidthPx: number;
   setCustomEditorWidthPx: (px: number) => void;
   setEditorMaxWidthLive: (value: string) => void;
+  sidebarWidthPx: number | null;
+  setSidebarWidthPx: (px: number | null) => void;
+  setSidebarWidthLive: (px: number) => void;
   customColorsLight: CustomColors;
   customColorsDark: CustomColors;
   setCustomColor: (mode: "light" | "dark", key: ThemeColorKey, value: string) => void;
@@ -187,6 +191,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const [customEditorWidthPx, setCustomEditorWidthPxState] = useState<number>(
     DEFAULT_CUSTOM_WIDTH_PX
   );
+  const [sidebarWidthPx, setSidebarWidthPxState] = useState<number | null>(null);
   const [customColorsLight, setCustomColorsLightState] = useState<CustomColors>({});
   const [customColorsDark, setCustomColorsDarkState] = useState<CustomColors>({});
   const [isInitialized, setIsInitialized] = useState(false);
@@ -241,6 +246,13 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         settings.customEditorWidthPx >= 480
       ) {
         setCustomEditorWidthPxState(settings.customEditorWidthPx);
+      }
+      if (
+        typeof settings.sidebarWidthPx === "number" &&
+        settings.sidebarWidthPx >= SIDEBAR_MIN_PX &&
+        settings.sidebarWidthPx <= SIDEBAR_MAX_PX
+      ) {
+        setSidebarWidthPxState(settings.sidebarWidthPx);
       }
       if (settings.customColorsLight) {
         setCustomColorsLightState(settings.customColorsLight);
@@ -329,6 +341,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     applyLayoutCSSVariables(editorWidth, customEditorWidthPx);
   }, [editorWidth, customEditorWidthPx]);
 
+  // Apply sidebar width CSS variable whenever it changes (null = no override, fallback to 16rem)
+  useEffect(() => {
+    if (sidebarWidthPx === null) {
+      document.documentElement.style.removeProperty("--sidebar-width");
+    } else {
+      document.documentElement.style.setProperty("--sidebar-width", `${sidebarWidthPx}px`);
+    }
+  }, [sidebarWidthPx]);
+
   // Apply interface zoom whenever it changes (suppress transitions during zoom)
   useEffect(() => {
     const root = document.documentElement;
@@ -378,6 +399,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     setEditorWidthState("normal");
     setInterfaceZoomState(1.0);
     setCustomEditorWidthPxState(DEFAULT_CUSTOM_WIDTH_PX);
+    setSidebarWidthPxState(null);
     setCustomColorsLightState({});
     setCustomColorsDarkState({});
     try {
@@ -389,6 +411,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         editorWidth: "normal",
         interfaceZoom: 1.0,
         customEditorWidthPx: undefined,
+        sidebarWidthPx: undefined,
         customColorsLight: undefined,
         customColorsDark: undefined,
       });
@@ -458,6 +481,29 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       });
     } catch (error) {
       console.error("Failed to save custom editor width:", error);
+    }
+  }, []);
+
+  // Set sidebar width in px (persists to settings). Pass null to reset to default 16rem.
+  const setSidebarWidthPx = useCallback(async (px: number | null) => {
+    if (px === null) {
+      setSidebarWidthPxState(null);
+      document.documentElement.style.removeProperty("--sidebar-width");
+      try {
+        const settings = await getSettings();
+        await updateSettings({ ...settings, sidebarWidthPx: undefined });
+      } catch (error) {
+        console.error("Failed to reset sidebar width:", error);
+      }
+    } else {
+      const clamped = Math.round(Math.min(Math.max(px, SIDEBAR_MIN_PX), SIDEBAR_MAX_PX));
+      setSidebarWidthPxState(clamped);
+      try {
+        const settings = await getSettings();
+        await updateSettings({ ...settings, sidebarWidthPx: clamped });
+      } catch (error) {
+        console.error("Failed to save sidebar width:", error);
+      }
     }
   }, []);
 
@@ -549,6 +595,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     document.documentElement.style.setProperty("--editor-max-width", value);
   }, []);
 
+  // Live sidebar width update during drag (no persistence)
+  const setSidebarWidthLive = useCallback((px: number) => {
+    document.documentElement.style.setProperty("--sidebar-width", `${px}px`);
+  }, []);
+
   // Don't render until initialized to prevent flash
   if (!isInitialized) {
     return null;
@@ -574,6 +625,9 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         customEditorWidthPx,
         setCustomEditorWidthPx,
         setEditorMaxWidthLive,
+        sidebarWidthPx,
+        setSidebarWidthPx,
+        setSidebarWidthLive,
         customColorsLight,
         customColorsDark,
         setCustomColor,

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -1,3 +1,5 @@
+/** Default sidebar width in pixels when no override is set (16rem, the former `w-64`). */
+export const SIDEBAR_DEFAULT_PX = 256;
 /** Minimum allowed sidebar width in pixels. */
 export const SIDEBAR_MIN_PX = 180;
 /** Maximum allowed sidebar width in pixels. */

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -1,5 +1,4 @@
-// Sidebar width bounds (px), shared between the ThemeContext (persistence +
-// boot validation) and the SidebarResizeHandle (live drag clamping) so the
-// limits can never drift apart.
+/** Minimum allowed sidebar width in pixels. */
 export const SIDEBAR_MIN_PX = 180;
+/** Maximum allowed sidebar width in pixels. */
 export const SIDEBAR_MAX_PX = 800;

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -1,0 +1,5 @@
+// Sidebar width bounds (px), shared between the ThemeContext (persistence +
+// boot validation) and the SidebarResizeHandle (live drag clamping) so the
+// limits can never drift apart.
+export const SIDEBAR_MIN_PX = 180;
+export const SIDEBAR_MAX_PX = 800;

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -53,6 +53,7 @@ export interface Settings {
   textDirection?: TextDirection;
   editorWidth?: EditorWidth;
   customEditorWidthPx?: number;
+  sidebarWidthPx?: number;
   defaultNoteName?: string;
   interfaceZoom?: number;
   ollamaModel?: string;


### PR DESCRIPTION
## Summary

- Add an interactive drag handle on the right edge of the sidebar to customize its width
- The handle appears on hover; drag to resize in real-time with a live px indicator
- Keyboard accessible: focus the handle, then ←/→ (16px), Shift+←/→ (64px), Home/End (min/max)
- Double-click resets to the original width
- Opt-in by default: the sidebar keeps its original `16rem` width until you resize it; a custom width is then clamped to 180–800px and persisted in settings as `sidebarWidthPx`
- Hidden while the sidebar is collapsed or in focus mode
- Included in "Reset to defaults"

## Changes

| File | Description |
|------|-------------|
| `src-tauri/src/lib.rs` | Add `sidebarWidthPx` to the persisted `Settings` struct |
| `src/types/note.ts` | Add `sidebarWidthPx` to `Settings` |
| `src/lib/sidebar.ts` | New: shared sidebar width bounds (min/max) |
| `src/context/ThemeContext.tsx` | Sidebar width state (null until resized), validated load, setters, reset, `--sidebar-width` variable |
| `src/components/layout/SidebarResizeHandle.tsx` | New: drag + keyboard resize handle with live indicator and double-click reset |
| `src/components/layout/Sidebar.tsx` | Let the sidebar root fill its container (`w-64` → `w-full`) |
| `src/App.tsx` | Drive sidebar width via `--sidebar-width` (fallback `16rem`), mount the handle |
| `src/App.css` | Suppress the sidebar transition during drag |

## Test plan

- [x] `npm run build` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] Handle appears on hover at the right edge of the sidebar
- [x] Dragging resizes the sidebar and its content in real-time with a px indicator
- [x] Keyboard: ←/→ (16px), Shift+←/→ (64px), Home/End (min/max); focus indicator visible
- [x] Double-click resets to the original width
- [x] Width persists after closing and reopening the app
- [x] No change to the default layout until the sidebar is resized
- [x] Hidden in focus mode / when the sidebar is collapsed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive sidebar resizing via a draggable handle or keyboard controls (Arrow keys; Shift for larger steps; Home/End for min/max).
  * Double-click the handle resets the sidebar width to the default.
  * Sidebar width is saved per folder and restored when you return.
* **UX Improvements**
  * Improves resize smoothness by temporarily disabling sidebar transitions during drag.
  * The resize handle is shown only when the sidebar is visible and focus mode is inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->