### PR TITLE
feat: add GitHub-style alert blockquotes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -644,7 +644,63 @@ html.dark {
   color: var(--color-text-muted);
   border-left-color: var(--color-border);
   border-inline-start-color: var(--color-border);
+  font-weight: normal;
+  font-style: normal;
 }
+
+/* Remove Tailwind Typography default quote marks on blockquote paragraphs */
+.prose
+  :where(blockquote p:first-of-type):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  )::before,
+.prose
+  :where(blockquote p:last-of-type):not(
+    :where([class~="not-prose"], [class~="not-prose"] *)
+  )::after {
+  content: "";
+}
+
+/* Alert blockquotes */
+.prose blockquote.alert {
+  font-weight: normal;
+  font-style: normal;
+  color: var(--color-text);
+  border-left-width: 3px;
+  border-left-style: solid;
+  padding: 0.6em 1em;
+  margin: 1em 0;
+  border-radius: 0 4px 4px 0;
+  background-color: var(--color-bg-muted);
+}
+
+.prose blockquote.alert::before {
+  display: block;
+  font-weight: 600;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.4em;
+}
+
+.prose blockquote.alert p {
+  margin: 0;
+  color: var(--color-text);
+}
+
+.prose blockquote.alert-note  { border-left-color: #4493f8; }
+.prose blockquote.alert-note::before  { content: "Note";      color: #4493f8; }
+
+.prose blockquote.alert-tip   { border-left-color: #3fb950; }
+.prose blockquote.alert-tip::before   { content: "Tip";       color: #3fb950; }
+
+.prose blockquote.alert-important { border-left-color: #ab7df8; }
+.prose blockquote.alert-important::before { content: "Important"; color: #ab7df8; }
+
+.prose blockquote.alert-warning { border-left-color: #d29922; }
+.prose blockquote.alert-warning::before { content: "Warning";  color: #d29922; }
+
+.prose blockquote.alert-caution { border-left-color: #f85149; }
+.prose blockquote.alert-caution::before { content: "Caution";  color: #f85149; }
 
 /* Search match highlighting - uses the selection color */
 .search-match {

--- a/src/App.css
+++ b/src/App.css
@@ -665,11 +665,12 @@ html.dark {
   font-weight: normal;
   font-style: normal;
   color: var(--color-text);
-  border-left-width: 3px;
-  border-left-style: solid;
+  border-inline-start-width: 3px;
+  border-inline-start-style: solid;
   padding: 0.6em 1em;
   margin: 1em 0;
-  border-radius: 0 4px 4px 0;
+  border-start-end-radius: 4px;
+  border-end-end-radius: 4px;
   background-color: var(--color-bg-muted);
 }
 
@@ -687,19 +688,19 @@ html.dark {
   color: var(--color-text);
 }
 
-.prose blockquote.alert-note  { border-left-color: #4493f8; }
+.prose blockquote.alert-note  { border-inline-start-color: #4493f8; }
 .prose blockquote.alert-note::before  { content: "Note";      color: #4493f8; }
 
-.prose blockquote.alert-tip   { border-left-color: #3fb950; }
+.prose blockquote.alert-tip   { border-inline-start-color: #3fb950; }
 .prose blockquote.alert-tip::before   { content: "Tip";       color: #3fb950; }
 
-.prose blockquote.alert-important { border-left-color: #ab7df8; }
+.prose blockquote.alert-important { border-inline-start-color: #ab7df8; }
 .prose blockquote.alert-important::before { content: "Important"; color: #ab7df8; }
 
-.prose blockquote.alert-warning { border-left-color: #d29922; }
+.prose blockquote.alert-warning { border-inline-start-color: #d29922; }
 .prose blockquote.alert-warning::before { content: "Warning";  color: #d29922; }
 
-.prose blockquote.alert-caution { border-left-color: #f85149; }
+.prose blockquote.alert-caution { border-inline-start-color: #f85149; }
 .prose blockquote.alert-caution::before { content: "Caution";  color: #f85149; }
 
 /* Search match highlighting - uses the selection color */

--- a/src/components/editor/AlertBlockquote.ts
+++ b/src/components/editor/AlertBlockquote.ts
@@ -1,0 +1,107 @@
+import { Node, mergeAttributes, InputRule, type JSONContent, type MarkdownToken } from "@tiptap/core";
+
+export type AlertType = "NOTE" | "TIP" | "IMPORTANT" | "WARNING" | "CAUTION";
+
+const ALERT_TYPES: AlertType[] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+
+export const AlertBlockquote = Node.create({
+  name: "alertBlockquote",
+  group: "block",
+  content: "block+",
+  defining: true,
+
+  addAttributes() {
+    return {
+      alertType: {
+        default: "NOTE",
+        parseHTML: (el) => (el.getAttribute("data-alert-type") as AlertType) || "NOTE",
+        renderHTML: (attrs) => ({ "data-alert-type": attrs.alertType }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "blockquote[data-alert-type]" }];
+  },
+
+  renderHTML({ node, HTMLAttributes }) {
+    const type = ((node.attrs.alertType as string) || "NOTE").toLowerCase();
+    return [
+      "blockquote",
+      mergeAttributes(HTMLAttributes, { class: `alert alert-${type}` }),
+      0,
+    ];
+  },
+
+  addInputRules() {
+    const nodeType = this.type;
+    return ALERT_TYPES.map((alertType) =>
+      new InputRule({
+        find: new RegExp(`^\\[!${alertType}\\]\\s$`, "i"),
+        handler: ({ state, range, commands }) => {
+          const { $from } = state.selection;
+          let bqPos = -1;
+          for (let d = $from.depth; d >= 1; d--) {
+            if ($from.node(d).type.name === "blockquote") {
+              bqPos = $from.before(d);
+              break;
+            }
+          }
+          if (bqPos === -1) return;
+
+          commands.command(({ tr }) => {
+            tr.delete(range.from, range.to);
+            const bq = tr.doc.nodeAt(bqPos);
+            if (!bq) return true;
+            const alertNode = nodeType.create({ alertType }, bq.content);
+            tr.replaceWith(bqPos, bqPos + bq.nodeSize, alertNode);
+            return true;
+          });
+        },
+      }),
+    );
+  },
+
+  markdownTokenName: "alertBlockquote",
+
+  markdownTokenizer: {
+    name: "alertBlockquote",
+    level: "block" as const,
+    start: "> [!",
+    tokenize(src: string, _tokens: MarkdownToken[]) {
+      const match = src.match(
+        /^> \[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\r?\n?((?:>[ \t]?[^\n]*\r?\n?)*)/i,
+      );
+      if (!match) return undefined;
+      const text = (match[2] || "").replace(/^>[ \t]?/gm, "").replace(/\s+$/, "");
+      return {
+        type: "alertBlockquote",
+        raw: match[0],
+        alertType: match[1].toUpperCase(),
+        text,
+      };
+    },
+  },
+
+  parseMarkdown(token: MarkdownToken, helpers) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const t = token as any;
+    const alertType: string = t.alertType || "NOTE";
+    const text: string = t.text || "";
+    // Split on blank lines → multiple paragraphs; soft newlines → space
+    const blocks = text.split(/\n\n+/).map((p) => p.replace(/\n/g, " ").trim()).filter(Boolean);
+    const paraNodes = blocks.length > 0
+      ? blocks.map((p) => helpers.createNode("paragraph", {}, [helpers.createTextNode(p)]))
+      : [helpers.createNode("paragraph", {}, [])];
+    return helpers.createNode("alertBlockquote", { alertType }, paraNodes);
+  },
+
+  renderMarkdown(node: JSONContent, helpers) {
+    const alertType = (node.attrs?.alertType as string) || "NOTE";
+    const raw = node.content ? helpers.renderChildren(node.content) : "";
+    const inner = raw.replace(/\s+$/, "");
+    const lines = inner.split("\n").map((l) => (l ? `> ${l}` : ">"));
+    return `> [!${alertType}]\n${lines.join("\n")}`;
+  },
+});

--- a/src/components/editor/AlertBlockquote.ts
+++ b/src/components/editor/AlertBlockquote.ts
@@ -19,6 +19,12 @@ function normalizeAlertType(value: unknown): AlertType {
   return (ALERT_TYPES as string[]).includes(upper) ? (upper as AlertType) : "NOTE";
 }
 
+// Built from ALERT_TYPES so the tokenizer always matches exactly the types we support
+const ALERT_TOKEN_RE = new RegExp(
+  `^> \\[!(${ALERT_TYPES.join("|")})\\][ \\t]*\\r?\\n?((?:>[ \\t]?[^\\n]*\\r?\\n?)*)`,
+  "i",
+);
+
 
 export const AlertBlockquote = Node.create({
   name: "alertBlockquote",
@@ -89,9 +95,7 @@ export const AlertBlockquote = Node.create({
     level: "block" as const,
     start: "> [!",
     tokenize(src: string, _tokens: MarkdownToken[]) {
-      const match = src.match(
-        /^> \[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\r?\n?((?:>[ \t]?[^\n]*\r?\n?)*)/i,
-      );
+      const match = src.match(ALERT_TOKEN_RE);
       if (!match) return undefined;
       const text = (match[2] || "").replace(/^>[ \t]?/gm, "").replace(/\s+$/, "");
       return {

--- a/src/components/editor/AlertBlockquote.ts
+++ b/src/components/editor/AlertBlockquote.ts
@@ -2,7 +2,22 @@ import { Node, mergeAttributes, InputRule, type JSONContent, type MarkdownToken 
 
 export type AlertType = "NOTE" | "TIP" | "IMPORTANT" | "WARNING" | "CAUTION";
 
-const ALERT_TYPES: AlertType[] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+export const ALERT_TYPES: AlertType[] = ["NOTE", "TIP", "IMPORTANT", "WARNING", "CAUTION"];
+
+// Single source of truth for label/color, shared by the toolbar buttons,
+// slash commands, and the accessible label rendered on each alert.
+export const ALERT_META: Record<AlertType, { label: string; color: string }> = {
+  NOTE: { label: "Note", color: "#4493f8" },
+  TIP: { label: "Tip", color: "#3fb950" },
+  IMPORTANT: { label: "Important", color: "#ab7df8" },
+  WARNING: { label: "Warning", color: "#d29922" },
+  CAUTION: { label: "Caution", color: "#f85149" },
+};
+
+function normalizeAlertType(value: unknown): AlertType {
+  const upper = typeof value === "string" ? value.toUpperCase() : "";
+  return (ALERT_TYPES as string[]).includes(upper) ? (upper as AlertType) : "NOTE";
+}
 
 
 export const AlertBlockquote = Node.create({
@@ -15,7 +30,7 @@ export const AlertBlockquote = Node.create({
     return {
       alertType: {
         default: "NOTE",
-        parseHTML: (el) => (el.getAttribute("data-alert-type") as AlertType) || "NOTE",
+        parseHTML: (el) => normalizeAlertType(el.getAttribute("data-alert-type")),
         renderHTML: (attrs) => ({ "data-alert-type": attrs.alertType }),
       },
     };
@@ -26,10 +41,14 @@ export const AlertBlockquote = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    const type = ((node.attrs.alertType as string) || "NOTE").toLowerCase();
+    const alertType = normalizeAlertType(node.attrs.alertType);
+    const { label } = ALERT_META[alertType];
     return [
       "blockquote",
-      mergeAttributes(HTMLAttributes, { class: `alert alert-${type}` }),
+      mergeAttributes(HTMLAttributes, {
+        class: `alert alert-${alertType.toLowerCase()}`,
+        "aria-label": `${label} callout`,
+      }),
       0,
     ];
   },
@@ -78,7 +97,7 @@ export const AlertBlockquote = Node.create({
       return {
         type: "alertBlockquote",
         raw: match[0],
-        alertType: match[1].toUpperCase(),
+        alertType: normalizeAlertType(match[1]),
         text,
       };
     },
@@ -87,7 +106,7 @@ export const AlertBlockquote = Node.create({
   parseMarkdown(token: MarkdownToken, helpers) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const t = token as any;
-    const alertType: string = t.alertType || "NOTE";
+    const alertType = normalizeAlertType(t.alertType);
     const text: string = t.text || "";
     // Split on blank lines → multiple paragraphs; soft newlines → space
     const blocks = text.split(/\n\n+/).map((p) => p.replace(/\n/g, " ").trim()).filter(Boolean);
@@ -98,7 +117,7 @@ export const AlertBlockquote = Node.create({
   },
 
   renderMarkdown(node: JSONContent, helpers) {
-    const alertType = (node.attrs?.alertType as string) || "NOTE";
+    const alertType = normalizeAlertType(node.attrs?.alertType);
     const raw = node.content ? helpers.renderChildren(node.content) : "";
     const inner = raw.replace(/\s+$/, "");
     const lines = inner.split("\n").map((l) => (l ? `> ${l}` : ">"));

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -69,7 +69,7 @@ import { Wikilink, type WikilinkStorage } from "./Wikilink";
 import { WikilinkSuggestion } from "./WikilinkSuggestion";
 import { EditorWidthHandles } from "./EditorWidthHandle";
 import { ScratchBlockMath, normalizeBlockMath } from "./MathExtensions";
-import { AlertBlockquote } from "./AlertBlockquote";
+import { AlertBlockquote, ALERT_TYPES, ALERT_META } from "./AlertBlockquote";
 import { cn } from "../../lib/utils";
 import { plainTextFromMarkdown } from "../../lib/plainText";
 import { Button, IconButton, ToolbarButton, Tooltip } from "../ui";
@@ -346,32 +346,27 @@ function FormatBar({
       >
         <QuoteIcon className="w-4.5 h-4.5 stroke-[1.5]" />
       </ToolbarButton>
-      {(
-        [
-          { alertType: "NOTE",      label: "Note",      color: "#4493f8" },
-          { alertType: "TIP",       label: "Tip",       color: "#3fb950" },
-          { alertType: "IMPORTANT", label: "Important", color: "#ab7df8" },
-          { alertType: "WARNING",   label: "Warning",   color: "#d29922" },
-          { alertType: "CAUTION",   label: "Caution",   color: "#f85149" },
-        ] as { alertType: string; label: string; color: string }[]
-      ).map(({ alertType, label, color }) => (
-        <ToolbarButton
-          key={alertType}
-          onClick={() =>
-            editor.chain().focus().wrapIn("alertBlockquote", { alertType }).run()
-          }
-          isActive={editor.isActive("alertBlockquote", { alertType })}
-          title={`Alert: ${label}`}
-        >
-          <span className="relative flex items-center justify-center">
-            <QuoteIcon className="w-4.5 h-4.5 stroke-[1.5]" />
-            <span
-              className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full"
-              style={{ background: color }}
-            />
-          </span>
-        </ToolbarButton>
-      ))}
+      {ALERT_TYPES.map((alertType) => {
+        const { label, color } = ALERT_META[alertType];
+        return (
+          <ToolbarButton
+            key={alertType}
+            onClick={() =>
+              editor.chain().focus().wrapIn("alertBlockquote", { alertType }).run()
+            }
+            isActive={editor.isActive("alertBlockquote", { alertType })}
+            title={`Alert: ${label}`}
+          >
+            <span className="relative flex items-center justify-center">
+              <QuoteIcon className="w-4.5 h-4.5 stroke-[1.5]" />
+              <span
+                className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full"
+                style={{ background: color }}
+              />
+            </span>
+          </ToolbarButton>
+        );
+      })}
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleCode().run()}
         isActive={editor.isActive("code")}

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -69,6 +69,7 @@ import { Wikilink, type WikilinkStorage } from "./Wikilink";
 import { WikilinkSuggestion } from "./WikilinkSuggestion";
 import { EditorWidthHandles } from "./EditorWidthHandle";
 import { ScratchBlockMath, normalizeBlockMath } from "./MathExtensions";
+import { AlertBlockquote } from "./AlertBlockquote";
 import { cn } from "../../lib/utils";
 import { plainTextFromMarkdown } from "../../lib/plainText";
 import { Button, IconButton, ToolbarButton, Tooltip } from "../ui";
@@ -345,6 +346,32 @@ function FormatBar({
       >
         <QuoteIcon className="w-4.5 h-4.5 stroke-[1.5]" />
       </ToolbarButton>
+      {(
+        [
+          { alertType: "NOTE",      label: "Note",      color: "#4493f8" },
+          { alertType: "TIP",       label: "Tip",       color: "#3fb950" },
+          { alertType: "IMPORTANT", label: "Important", color: "#ab7df8" },
+          { alertType: "WARNING",   label: "Warning",   color: "#d29922" },
+          { alertType: "CAUTION",   label: "Caution",   color: "#f85149" },
+        ] as { alertType: string; label: string; color: string }[]
+      ).map(({ alertType, label, color }) => (
+        <ToolbarButton
+          key={alertType}
+          onClick={() =>
+            editor.chain().focus().wrapIn("alertBlockquote", { alertType }).run()
+          }
+          isActive={editor.isActive("alertBlockquote", { alertType })}
+          title={`Alert: ${label}`}
+        >
+          <span className="relative flex items-center justify-center">
+            <QuoteIcon className="w-4.5 h-4.5 stroke-[1.5]" />
+            <span
+              className="absolute -bottom-0.5 -right-0.5 size-1.5 rounded-full"
+              style={{ background: color }}
+            />
+          </span>
+        </ToolbarButton>
+      ))}
       <ToolbarButton
         onClick={() => editor.chain().focus().toggleCode().run()}
         isActive={editor.isActive("code")}
@@ -1109,6 +1136,7 @@ export function Editor({
         },
       }),
       Frontmatter,
+      AlertBlockquote,
       Markdown.configure({}),
       SearchHighlight.configure({
         matches: [],

--- a/src/components/editor/SlashCommand.tsx
+++ b/src/components/editor/SlashCommand.tsx
@@ -23,6 +23,7 @@ import {
   BracketsIcon,
   WorkflowIcon,
 } from "../icons";
+import type { AlertType } from "./AlertBlockquote";
 import { SlashCommandList, type SlashCommandListRef } from "./SlashCommandList";
 
 export interface SlashCommandItem {
@@ -115,6 +116,26 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
       editor.chain().focus().toggleBlockquote().run();
     },
   },
+  ...([
+    { type: "NOTE",      label: "Note",      color: "#4493f8", aliases: ["note",      "info"] },
+    { type: "TIP",       label: "Tip",       color: "#3fb950", aliases: ["tip",       "hint"] },
+    { type: "IMPORTANT", label: "Important", color: "#ab7df8", aliases: ["important"        ] },
+    { type: "WARNING",   label: "Warning",   color: "#d29922", aliases: ["warning",   "warn"] },
+    { type: "CAUTION",   label: "Caution",   color: "#f85149", aliases: ["caution",   "danger"] },
+  ] as { type: AlertType; label: string; color: string; aliases: string[] }[]).map(({ type, label, color, aliases }) => ({
+    title: `Alert: ${label}`,
+    description: `${label} alert callout`,
+    icon: (
+      <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+        <QuoteIcon />
+        <span style={{ position: "absolute", bottom: -2, right: -3, width: 6, height: 6, borderRadius: "50%", background: color }} />
+      </div>
+    ),
+    aliases: [...aliases, "alert", "callout"],
+    command: (editor: TiptapEditor) => {
+      editor.chain().focus().wrapIn("alertBlockquote", { alertType: type }).run();
+    },
+  })),
   {
     title: "Code Block",
     description: "Fenced code block",

--- a/src/components/editor/SlashCommand.tsx
+++ b/src/components/editor/SlashCommand.tsx
@@ -23,7 +23,15 @@ import {
   BracketsIcon,
   WorkflowIcon,
 } from "../icons";
-import type { AlertType } from "./AlertBlockquote";
+import { ALERT_TYPES, ALERT_META, type AlertType } from "./AlertBlockquote";
+
+const ALERT_ALIASES: Record<AlertType, string[]> = {
+  NOTE: ["note", "info"],
+  TIP: ["tip", "hint"],
+  IMPORTANT: ["important"],
+  WARNING: ["warning", "warn"],
+  CAUTION: ["caution", "danger"],
+};
 import { SlashCommandList, type SlashCommandListRef } from "./SlashCommandList";
 
 export interface SlashCommandItem {
@@ -116,26 +124,23 @@ const SLASH_COMMANDS: SlashCommandItem[] = [
       editor.chain().focus().toggleBlockquote().run();
     },
   },
-  ...([
-    { type: "NOTE",      label: "Note",      color: "#4493f8", aliases: ["note",      "info"] },
-    { type: "TIP",       label: "Tip",       color: "#3fb950", aliases: ["tip",       "hint"] },
-    { type: "IMPORTANT", label: "Important", color: "#ab7df8", aliases: ["important"        ] },
-    { type: "WARNING",   label: "Warning",   color: "#d29922", aliases: ["warning",   "warn"] },
-    { type: "CAUTION",   label: "Caution",   color: "#f85149", aliases: ["caution",   "danger"] },
-  ] as { type: AlertType; label: string; color: string; aliases: string[] }[]).map(({ type, label, color, aliases }) => ({
-    title: `Alert: ${label}`,
-    description: `${label} alert callout`,
-    icon: (
-      <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
-        <QuoteIcon />
-        <span style={{ position: "absolute", bottom: -2, right: -3, width: 6, height: 6, borderRadius: "50%", background: color }} />
-      </div>
-    ),
-    aliases: [...aliases, "alert", "callout"],
-    command: (editor: TiptapEditor) => {
-      editor.chain().focus().wrapIn("alertBlockquote", { alertType: type }).run();
-    },
-  })),
+  ...ALERT_TYPES.map((type) => {
+    const { label, color } = ALERT_META[type];
+    return {
+      title: `Alert: ${label}`,
+      description: `${label} alert callout`,
+      icon: (
+        <div style={{ position: "relative", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <QuoteIcon />
+          <span style={{ position: "absolute", bottom: -2, right: -3, width: 6, height: 6, borderRadius: "50%", background: color }} />
+        </div>
+      ),
+      aliases: [...ALERT_ALIASES[type], "alert", "callout"],
+      command: (editor: TiptapEditor) => {
+        editor.chain().focus().wrapIn("alertBlockquote", { alertType: type }).run();
+      },
+    };
+  }),
   {
     title: "Code Block",
     description: "Fenced code block",


### PR DESCRIPTION
## Summary

- Adds the 5 GitHub/GFM alert types (`NOTE`, `TIP`, `IMPORTANT`, `WARNING`, `CAUTION`) as a dedicated TipTap node extension
- Three creation methods: InputRule (`> ` then `[!NOTE] `), slash commands (`/note`, `/tip`…), toolbar buttons
- Toolbar buttons show active state when cursor is inside an alert of that type
- Full markdown round-trip: alerts in existing `.md` files are parsed and rendered correctly; saving and reopening preserves them
- Modifies Tailwind Typography's default bold/italic styling on standard blockquotes, allowing styling

## Changes

**New file:** `src/components/editor/AlertBlockquote.ts`
New TipTap `Node` extension:
- Custom marked.js block tokenizer → parses `> [!TYPE]` syntax
- `parseMarkdown` / `renderMarkdown` → bidirectional markdown serialization
- `InputRule` → type `> ` then `[!NOTE] ` inside a blockquote to convert it to an alert
- `parseHTML` → handles `<blockquote data-alert-type="...">` for copy/paste

**Modified file:** `src/components/editor/Editor.tsx`
- Registers `AlertBlockquote` extension
- Adds 5 toolbar buttons after the existing blockquote button, each with a color-coded dot badge and active state detection

**Modified file:** `src/components/editor/SlashCommand.tsx`
- Adds 5 alert items with aliases: `alert`, `callout` (shared) + `info`, `hint`, `warn`, `danger` (type-specific)

**Modified file:** `src/App.css`
- Color-coded alert styles: left border + muted background + `::before` label per type
- Fixes Tailwind Typography default `font-weight: 500` / `font-style: italic` on blockquotes

## Known limitations

- **Inline formatting round-trip**: bold/italic/code inside an alert are preserved within a WYSIWYG session, but after toggling to source mode and back, marks appear as literal markdown syntax (`**text**`). This is a constraint of the `@tiptap/markdown` v3 custom block extension API, which does not expose the block-recursive inline processing pipeline to custom extensions.
- **Lists inside alerts**: rendered as plain text after a WYSIWYG ↔ source round-trip

## Tested so far

- [x] `npm run tauri build ` passes
- [x] Type `> ` then `[!NOTE] ` → blockquote converts to NOTE alert; repeat for all 5 types
- [x] Type `/note` in slash command → alert wraps current paragraph; repeat for all 5 types
- [x] Click each toolbar alert button → wraps current paragraph in the corresponding alert type
- [x] Click toolbar button while cursor is inside an alert → button shows active state
- [x] Press Enter inside an alert → new paragraph stays inside the alert
- [x] WYSIWYG → source mode → WYSIWYG: alert persists, rest of document intact
- [x] Save note with alerts → close Scratch → reopen: alerts restored correctly
- [x] Open an existing `.md` file containing `> [!NOTE]` syntax → rendered as styled alert
- [x] Cut/copy-paste an alert block → alert type and content preserved
- [x] All 5 types render correctly in dark mode
- [x] Standard blockquotes are no longer rendered bold/italic
- [x] PDF export: alerts render as styled blockquotes

## Visuals

<img width="1002" height="766" alt="image" src="https://github.com/user-attachments/assets/34fd8e65-791b-415b-95d5-cb923425122f" />

<img width="269" height="368" alt="image" src="https://github.com/user-attachments/assets/cf26f08c-d495-4921-9beb-32b8861a208d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added alert-style blockquotes with types: Note, Tip, Important, Warning, and Caution
  * Create alerts from the formatting toolbar, slash commands, and in-editor typing using `[!TYPE]`
  * Added markdown support for `> [!TYPE]` blockquote alerts
* **Styling**
  * Updated blockquote typography to remove default quote marks
  * Enabled labeled, color-coded alert variants with distinct left borders and alert type labels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->