### PR TITLE
feat: add Cmd+G shortcut to navigate to a note

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Editor } from "./components/editor/Editor";
 import type { Editor as TiptapEditor } from "@tiptap/react";
 import { FolderPicker } from "./components/layout/FolderPicker";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
+import { NoteNavigator } from "./components/editor/NoteNavigator";
 import { SettingsPage } from "./components/settings";
 import {
   SpinnerIcon,
@@ -67,6 +68,7 @@ function AppContent() {
   const currentNoteRef = useRef(currentNote);
   currentNoteRef.current = currentNote;
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [noteNavigatorOpen, setNoteNavigatorOpen] = useState(false);
   const [view, setView] = useState<ViewState>("notes");
   const [sidebarVisible, setSidebarVisible] = useState(true);
   const [aiModalOpen, setAiModalOpen] = useState(false);
@@ -285,6 +287,17 @@ function AppContent() {
         return;
       }
 
+      // Cmd+G - Go to note
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === "g") {
+        e.preventDefault();
+        if (currentNoteRef.current) {
+          window.dispatchEvent(new CustomEvent("navigate-to-note"));
+        } else {
+          setNoteNavigatorOpen(true);
+        }
+        return;
+      }
+
       // Cmd+Shift+P - Print
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "p") {
         e.preventDefault();
@@ -497,6 +510,28 @@ function AppContent() {
             if (aiModalOpen) setAiModalOpen(false);
           }}
         />
+      )}
+
+      {/* Note navigator overlay (used when no note is open and editor is unavailable) */}
+      {noteNavigatorOpen && (
+        <>
+          <div
+            className="fixed inset-0 bg-text/50 backdrop-blur-sm z-40 animate-fade-in"
+            onClick={() => setNoteNavigatorOpen(false)}
+          />
+          <div className="fixed inset-0 z-50 flex items-start justify-center pt-24 pointer-events-none">
+            <div className="pointer-events-auto">
+              <NoteNavigator
+                notes={notes}
+                onSelect={(note) => {
+                  setNoteNavigatorOpen(false);
+                  selectNote(note.id);
+                }}
+                onCancel={() => setNoteNavigatorOpen(false)}
+              />
+            </div>
+          </div>
+        </>
       )}
 
       <KeyboardShortcutsModal

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -63,6 +63,7 @@ import { useTheme } from "../../context/ThemeContext";
 import { Frontmatter } from "./Frontmatter";
 import { BlockMathEditor } from "./BlockMathEditor";
 import { LinkEditor } from "./LinkEditor";
+import { NoteNavigator } from "./NoteNavigator";
 import { SearchToolbar } from "./SearchToolbar";
 import { SlashCommand } from "./SlashCommand";
 import { Wikilink, type WikilinkStorage } from "./Wikilink";
@@ -74,7 +75,7 @@ import { plainTextFromMarkdown } from "../../lib/plainText";
 import { Button, IconButton, ToolbarButton, Tooltip } from "../ui";
 import * as notesService from "../../services/notes";
 import { downloadPdf, downloadMarkdown } from "../../services/pdf";
-import type { Settings } from "../../types/note";
+import type { Settings, NoteMetadata } from "../../types/note";
 import {
   BoldIcon,
   ItalicIcon,
@@ -584,6 +585,7 @@ export function Editor({
   const saveTimeoutRef = useRef<number | null>(null);
   const linkPopupRef = useRef<TippyInstance | null>(null);
   const blockMathPopupRef = useRef<TippyInstance | null>(null);
+  const noteNavigatorPopupRef = useRef<TippyInstance | null>(null);
   const isLoadingRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const editorRef = useRef<TiptapEditor | null>(null);
@@ -786,15 +788,27 @@ export function Editor({
     }
   }, []);
 
+  const closeLinkPopup = useCallback(() => {
+    if (linkPopupRef.current) {
+      linkPopupRef.current.destroy();
+      linkPopupRef.current = null;
+    }
+  }, []);
+
+  const closeNoteNavigatorPopup = useCallback(() => {
+    if (noteNavigatorPopupRef.current) {
+      noteNavigatorPopupRef.current.destroy();
+      noteNavigatorPopupRef.current = null;
+    }
+  }, []);
+
   const handleEditBlockMath = useCallback(
     (pos: number) => {
       const currentEditor = editorRef.current;
       if (!currentEditor) return;
 
-      if (linkPopupRef.current) {
-        linkPopupRef.current.destroy();
-        linkPopupRef.current = null;
-      }
+      closeLinkPopup();
+      closeNoteNavigatorPopup();
       closeBlockMathPopup();
 
       const node = currentEditor.state.doc.nodeAt(pos);
@@ -876,7 +890,7 @@ export function Editor({
         },
       });
     },
-    [closeBlockMathPopup],
+    [closeBlockMathPopup, closeLinkPopup, closeNoteNavigatorPopup],
   );
 
   const handleAddBlockMath = useCallback(() => {
@@ -1547,6 +1561,9 @@ export function Editor({
       if (blockMathPopupRef.current) {
         blockMathPopupRef.current.destroy();
       }
+      if (noteNavigatorPopupRef.current) {
+        noteNavigatorPopupRef.current.destroy();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run cleanup on unmount, not when saveNote changes
@@ -1555,14 +1572,12 @@ export function Editor({
   const handleAddLink = useCallback(() => {
     if (!editor) return;
 
-    // Close block math popup if open (popups are mutually exclusive)
+    // Close other popups if open (popups are mutually exclusive)
     closeBlockMathPopup();
+    closeNoteNavigatorPopup();
 
     // Destroy existing popup if any
-    if (linkPopupRef.current) {
-      linkPopupRef.current.destroy();
-      linkPopupRef.current = null;
-    }
+    closeLinkPopup();
 
     // Get existing link URL if cursor is on a link
     const existingUrl = editor.getAttributes("link").href || "";
@@ -1676,7 +1691,73 @@ export function Editor({
         component.destroy();
       },
     });
-  }, [editor, closeBlockMathPopup]);
+  }, [editor, closeBlockMathPopup, closeLinkPopup, closeNoteNavigatorPopup]);
+
+  // Navigate to note handler - show inline popup at cursor position
+  const handleGoToNote = useCallback(() => {
+    if (!editor) return;
+
+    closeBlockMathPopup();
+    closeLinkPopup();
+
+    // Toggle: second Cmd+G closes the popup
+    if (noteNavigatorPopupRef.current) {
+      noteNavigatorPopupRef.current.destroy();
+      noteNavigatorPopupRef.current = null;
+      editor.commands.focus();
+      return;
+    }
+
+    const currentNotes = notesRef.current ?? [];
+    const { from } = editor.state.selection;
+    const coords = editor.view.coordsAtPos(from);
+    const virtualElement = {
+      getBoundingClientRect: () =>
+        ({
+          width: 0,
+          height: 0,
+          top: coords.top,
+          left: coords.left,
+          right: coords.right,
+          bottom: coords.bottom,
+          x: coords.left,
+          y: coords.top,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    };
+
+    const component = new ReactRenderer(NoteNavigator, {
+      props: {
+        notes: currentNotes,
+        onSelect: (note: NoteMetadata) => {
+          noteNavigatorPopupRef.current?.destroy();
+          noteNavigatorPopupRef.current = null;
+          notesCtxRef.current?.selectNote(note.id);
+        },
+        onCancel: () => {
+          editor.commands.focus();
+          noteNavigatorPopupRef.current?.destroy();
+          noteNavigatorPopupRef.current = null;
+        },
+      },
+      editor,
+    });
+
+    noteNavigatorPopupRef.current = tippy(document.body, {
+      getReferenceClientRect: () =>
+        virtualElement.getBoundingClientRect() as DOMRect,
+      appendTo: () => document.body,
+      content: component.element,
+      showOnCreate: true,
+      interactive: true,
+      trigger: "manual",
+      placement: "bottom-start",
+      offset: [0, 8],
+      onDestroy: () => {
+        component.destroy();
+      },
+    });
+  }, [editor, closeBlockMathPopup, closeLinkPopup]);
 
   // Image handler
   const handleAddImage = useCallback(async () => {
@@ -1743,6 +1824,15 @@ export function Editor({
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [handleAddLink, editor]);
+
+  // Cmd+G to navigate to a note (dispatched globally from App.tsx)
+  useEffect(() => {
+    const handler = () => {
+      if (editor) handleGoToNote();
+    };
+    window.addEventListener("navigate-to-note", handler);
+    return () => window.removeEventListener("navigate-to-note", handler);
+  }, [handleGoToNote, editor]);
 
   // Keyboard shortcut for Cmd+Shift+C to open copy menu
   useEffect(() => {

--- a/src/components/editor/NoteNavigator.tsx
+++ b/src/components/editor/NoteNavigator.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useMemo, useRef } from "react";
+import { cleanTitle, cn } from "../../lib/utils";
+import type { NoteMetadata } from "../../types/note";
+
+interface NoteNavigatorProps {
+  notes: NoteMetadata[];
+  onSelect: (note: NoteMetadata) => void;
+  onCancel: () => void;
+}
+
+export const NoteNavigator = ({
+  notes,
+  onSelect,
+  onCancel,
+}: NoteNavigatorProps) => {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(
+    () =>
+      notes
+        .filter((n) =>
+          cleanTitle(n.title).toLowerCase().includes(query.toLowerCase()),
+        )
+        .slice(0, 10),
+    [notes, query],
+  );
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    const el = listRef.current?.querySelector(
+      `[data-index="${selectedIndex}"]`,
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      e.stopPropagation();
+      setSelectedIndex((i) => Math.min(i + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      e.stopPropagation();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (filtered[selectedIndex]) onSelect(filtered[selectedIndex]);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="bg-bg border border-border rounded-lg shadow-lg overflow-hidden w-72">
+      <div className="border-b border-border">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Go to note..."
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="w-full px-3 py-2 text-sm bg-transparent outline-none text-text placeholder:text-text-muted"
+        />
+      </div>
+      <div
+        ref={listRef}
+        className="p-1.5 max-h-60 overflow-y-auto flex flex-col gap-0.5"
+      >
+        {filtered.length === 0 ? (
+          <div className="text-sm text-text-muted px-3 py-2">
+            No matching notes
+          </div>
+        ) : (
+          filtered.map((note, i) => (
+            <div
+              key={note.id}
+              data-index={i}
+              role="button"
+              tabIndex={-1}
+              onClick={() => onSelect(note)}
+              className={cn(
+                "w-full text-left p-2 rounded-md transition-colors cursor-pointer",
+                selectedIndex === i
+                  ? "bg-bg-muted text-text"
+                  : "text-text hover:bg-bg-muted",
+              )}
+            >
+              <div className="flex flex-col min-w-0">
+                <span className="text-sm leading-snug font-medium truncate">
+                  {cleanTitle(note.title)}
+                </span>
+                {note.preview && (
+                  <span className="text-xs text-text-muted truncate mt-0.5">
+                    {note.preview}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -197,6 +197,16 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
     [search],
   );
 
+  // Sync highlighting / selection when note changes 
+  useEffect(() => {
+    if (selectedNoteId) {
+      setMultiSelectedNoteIds(new Set([selectedNoteId]));
+      setLastClickedNoteId(selectedNoteId);
+    } else {
+      setMultiSelectedNoteIds(new Set());
+    }
+  }, [selectedNoteId]);
+
   const toggleSearch = useCallback(() => {
     setSearchOpen((prev) => {
       if (prev) {

--- a/src/lib/shortcuts.ts
+++ b/src/lib/shortcuts.ts
@@ -15,6 +15,7 @@ export const shortcutCategories: ShortcutCategory[] = [
     title: "Navigation",
     shortcuts: [
       { keys: [mod, "P"], description: "Command palette" },
+      { keys: [mod, "G"], description: "Go to note" },
       { keys: [mod, shift, "F"], description: "Search notes" },
       { keys: [mod, "\\"], description: "Toggle sidebar" },
       { keys: [mod, ","], description: "Settings" },


### PR DESCRIPTION
Adds a global Cmd+G (Ctrl+G on Windows/Linux) shortcut that opens a searchable popup to jump to any note without modifying the current page. When a note is open the popup appears inline near the cursor; when no note is open it shows as a centered overlay.

This is based on the link editor (Cmd+K) that is used to insert a link to another wiki page - copying the same basic control and behaviour but making it available as a keyboard-shortcut friendly navigation interaction.

I've also updated the Sidebar so that the highlighting for the currently-selected page reflects the right page after a Cmd+G. This was arguably a separate issue as this feels like it was a bug affecting clicking on Wikilinks on pages, too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a note navigator for quickly searching and jumping to notes.
  * Introduced a new keyboard shortcut: **Cmd/Ctrl+G** to open “Go to note.”
  * Added an inline note picker in the editor, with keyboard navigation and quick selection.

* **Bug Fixes**
  * Improved popup behavior so note navigation stays consistent when switching between inline editors.
  * Kept sidebar selection in sync when the active note changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->