### PR TITLE
fix: rename deb package to scratch-notes to avoid Ubuntu name collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,63 @@ jobs:
           prerelease: false
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}
+
+  # The deb ships as "scratch", which collides with an unrelated package in
+  # the Ubuntu repos (#119). Repack it as "scratch-notes" after all platform
+  # builds finish, re-sign it, and point the updater manifest at the new
+  # asset. Runs last so the latest.json swap can't race the matrix jobs.
+  rename-deb-package:
+    needs: build-and-release
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Repack deb as scratch-notes and update release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          tag="v${version}"
+          old_deb="Scratch_${version}_amd64.deb"
+          new_deb="scratch-notes_${version}_amd64.deb"
+          work=$(mktemp -d)
+
+          gh release download "$tag" --pattern "$old_deb" --dir "$work"
+          gh release download "$tag" --pattern latest.json --dir "$work"
+
+          # Replaces (without Conflicts) lets dpkg take over the files of an
+          # installed old-name deb, so in-app updates keep working for
+          # existing users.
+          dpkg-deb -R "$work/$old_deb" "$work/pkg"
+          sed -i 's/^Package: scratch$/Package: scratch-notes/' "$work/pkg/DEBIAN/control"
+          grep -q '^Package: scratch-notes$' "$work/pkg/DEBIAN/control"
+          echo "Replaces: scratch" >> "$work/pkg/DEBIAN/control"
+          dpkg-deb -b --root-owner-group "$work/pkg" "$work/$new_deb"
+
+          # Re-sign the repacked deb and swap the updater manifest entry;
+          # the signer CLI reads the key and password from the env vars.
+          npm run tauri -- signer sign "$work/$new_deb"
+          jq --arg sig "$(cat "$work/${new_deb}.sig")" \
+             --arg url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${tag}/${new_deb}" \
+             '.platforms["linux-x86_64-deb"].url = $url
+              | .platforms["linux-x86_64-deb"].signature = $sig' \
+             "$work/latest.json" > "$work/latest.json.new"
+          mv "$work/latest.json.new" "$work/latest.json"
+
+          gh release upload "$tag" "$work/$new_deb" "$work/${new_deb}.sig" --clobber
+          gh release upload "$tag" "$work/latest.json" --clobber
+          gh release delete-asset "$tag" "$old_deb" -y
+          gh release delete-asset "$tag" "${old_deb}.sig" -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,11 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      # Don't persist the git token: npm ci runs lifecycle scripts, and the
+      # gh/signer steps below only use env vars
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fixes #119 by implementing the post-build repack approach: a new `rename-deb-package` job in the release workflow repacks the deb as `scratch-notes` after all platform builds finish.

**Why it's more than a rename:** `latest.json` has a `linux-x86_64-deb` updater entry pointing at the deb with a signature over its exact bytes, so a plain rename would 404 the URL and invalidate the signature, breaking in-app updates for deb installs. The job therefore also re-signs the repacked deb with the existing updater key and patches the `linux-x86_64-deb` url + signature in `latest.json`.

**Design notes:**
- Runs after the full build matrix (`needs: build-and-release`) so the `latest.json` swap can't race the per-platform updater-json merging.
- The control file gains `Replaces: scratch` so dpkg can take over the files of an installed old-name deb — in-app updates keep working for existing users. Deliberately no `Conflicts: scratch`: it would make `dpkg -i` refuse to upgrade existing installs, and there's no file overlap to guard against (Ubuntu's scratch ships `/usr/bin/scratch`; ours ships `/usr/bin/Scratch`).
- New assets are uploaded before old ones are deleted, so a mid-job failure still leaves a valid (old-name) release.

**Verified:** control-file patch tested against the real v0.10.0 deb, jq manifest patch tested against the real v0.10.0 `latest.json` (all other platform entries untouched), YAML and bash syntax checked. The job runs for real on the next tag.

Suggested release-note line for the next release: deb users upgrading can optionally run `sudo apt remove scratch` afterward to drop the old package entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux Debian releases are now published under the `scratch-notes` package name.
  * Existing `scratch` installations can be replaced or upgraded automatically.
  * Release metadata now points to the renamed package and its updated signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->