### PR TITLE
fix: stop Ollama word-duplication by using its HTTP API instead of the CLI

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "objc2-foundation",
  "open",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "tantivy",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ regex = "1"
 walkdir = "2"
 tauri-plugin-single-instance = "2"
 chrono = "0.4"
+reqwest = { version = "0.13", default-features = false, features = ["json"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2-foundation = { version = "0.3", features = ["NSUserDefaults", "NSString"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3404,7 +3404,13 @@ async fn ai_execute_ollama(
         trimmed.to_string()
     };
 
-    let client = reqwest::Client::new();
+    // Non-streaming generation of a whole note can be slow (model load + full
+    // response), so this needs a generous timeout rather than none at all —
+    // otherwise a stalled Ollama request hangs the command forever.
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
     let response = match client
         .post("http://localhost:11434/api/generate")
         .json(&serde_json::json!({
@@ -3425,6 +3431,16 @@ async fn ai_execute_ollama(
                 output: String::new(),
                 error: Some(
                     "Could not connect to Ollama. Make sure it's running (`ollama serve`)."
+                        .to_string(),
+                ),
+            });
+        }
+        Err(e) if e.is_timeout() => {
+            return Ok(AiExecutionResult {
+                success: false,
+                output: String::new(),
+                error: Some(
+                    "Ollama did not respond in time. The model may still be loading."
                         .to_string(),
                 ),
             });
@@ -3472,17 +3488,27 @@ async fn ai_execute_ollama(
     #[derive(Deserialize)]
     struct OllamaGenerateResponse {
         response: String,
+        // Option, not String: models without thinking support can send this
+        // back as explicit JSON null rather than omitting it or using "".
         #[serde(default)]
-        thinking: String,
+        thinking: Option<String>,
     }
 
-    let body: OllamaGenerateResponse = response
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse Ollama response: {}", e))?;
+    let body: OllamaGenerateResponse = match response.json().await {
+        Ok(body) => body,
+        Err(e) => {
+            return Ok(AiExecutionResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Failed to parse Ollama response: {}", e)),
+            });
+        }
+    };
 
-    if !body.thinking.is_empty() {
-        eprintln!("Ollama thinking output ({} chars, discarded)", body.thinking.len());
+    if let Some(thinking) = &body.thinking {
+        if !thinking.is_empty() {
+            eprintln!("Ollama thinking output ({} chars, discarded)", thinking.len());
+        }
     }
 
     let edited_content = body.response.trim().to_string();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3387,7 +3387,7 @@ async fn ai_execute_ollama(
         .await
         .map_err(|e| format!("Failed to read file: {}", e))?;
 
-    let stdin_input = format!(
+    let full_prompt = format!(
         "You are a markdown editor. Edit the markdown content below according to the user's instructions.\n\
          Return ONLY the complete edited markdown content.\n\
          Do NOT include any explanation, commentary, or code fences around the output.\n\
@@ -3404,97 +3404,105 @@ async fn ai_execute_ollama(
         trimmed.to_string()
     };
 
-    // Check if the model is available locally before running (skip for cloud models)
-    if !model_name.contains("cloud") {
-        let mn = model_name.clone();
-        let available = tauri::async_runtime::spawn_blocking(move || {
-            let path = get_expanded_path();
-            let mut cmd = no_window_cmd("ollama");
-            cmd.env("PATH", &path);
-            cmd.args(["show", &mn]);
-            cmd.stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null());
-            match cmd.status() {
-                Ok(status) => status.success(),
-                Err(_) => false,
-            }
-        })
+    let client = reqwest::Client::new();
+    let response = match client
+        .post("http://localhost:11434/api/generate")
+        .json(&serde_json::json!({
+            "model": model_name,
+            "prompt": full_prompt,
+            // Ollama returns thinking output in a separate "thinking" field
+            // from "response", so enabling it doesn't leak into the note content.
+            "think": true,
+            "stream": false,
+        }))
+        .send()
         .await
-        .unwrap_or(false);
-
-        if !available {
+    {
+        Ok(response) => response,
+        Err(e) if e.is_connect() => {
             return Ok(AiExecutionResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!(
-                    "Model '{}' is not installed. Run: ollama pull {}",
-                    model_name, model_name
-                )),
+                error: Some(
+                    "Could not connect to Ollama. Make sure it's running (`ollama serve`)."
+                        .to_string(),
+                ),
             });
         }
-    }
-
-    let result = execute_ai_cli(
-        "Ollama",
-        "ollama".to_string(),
-        vec!["run".to_string(), model_name.clone()],
-        stdin_input,
-        "Ollama CLI not found. Please install it from https://ollama.com".to_string(),
-        None,
-        None,
-    )
-    .await?;
-
-    // Improve error messages for common Ollama failures
-    if !result.success {
-        if let Some(ref err) = result.error {
-            let err_lower = err.to_lowercase();
-            if err_lower.contains("file does not exist")
-                || err_lower.contains("pull model manifest")
-                || err_lower.contains("model not found")
-                || err_lower.contains("model does not exist")
-            {
-                return Ok(AiExecutionResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some(format!(
-                        "Model '{}' not found. Run `ollama pull {}` in your terminal to download it.",
-                        model_name, model_name
-                    )),
-                });
-            }
-            if err.contains("401") || err.contains("Unauthorized") {
-                return Ok(AiExecutionResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some("Authentication required. Run `ollama login` in your terminal to sign in.".to_string()),
-                });
-            }
-        }
-    }
-
-    // If successful, write the output back to the file
-    if result.success {
-        let edited_content = result.output.trim().to_string();
-        if edited_content.is_empty() {
+        Err(e) => {
             return Ok(AiExecutionResult {
                 success: false,
                 output: String::new(),
-                error: Some("Ollama returned empty output. Please try again.".to_string()),
+                error: Some(format!("Failed to reach Ollama: {}", e)),
             });
         }
-        tokio::fs::write(&canonical, edited_content.as_bytes())
+    };
+
+    let status = response.status();
+    if !status.is_success() {
+        #[derive(Deserialize)]
+        struct OllamaError {
+            error: String,
+        }
+
+        let message = response
+            .json::<OllamaError>()
             .await
-            .map_err(|e| format!("Failed to write edited file: {}", e))?;
+            .map(|e| e.error)
+            .unwrap_or_else(|_| format!("Ollama request failed with status {}", status));
 
-        Ok(AiExecutionResult {
-            success: true,
-            output: "Note edited successfully with Ollama.".to_string(),
-            error: None,
-        })
-    } else {
-        Ok(result)
+        let error = if status == reqwest::StatusCode::NOT_FOUND {
+            format!(
+                "Model '{}' not found. Run `ollama pull {}` in your terminal to download it.",
+                model_name, model_name
+            )
+        } else if status == reqwest::StatusCode::UNAUTHORIZED {
+            "Authentication required. Run `ollama login` in your terminal to sign in.".to_string()
+        } else {
+            message
+        };
+
+        return Ok(AiExecutionResult {
+            success: false,
+            output: String::new(),
+            error: Some(error),
+        });
     }
+
+    #[derive(Deserialize)]
+    struct OllamaGenerateResponse {
+        response: String,
+        #[serde(default)]
+        thinking: String,
+    }
+
+    let body: OllamaGenerateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Ollama response: {}", e))?;
+
+    if !body.thinking.is_empty() {
+        eprintln!("Ollama thinking output ({} chars, discarded)", body.thinking.len());
+    }
+
+    let edited_content = body.response.trim().to_string();
+    if edited_content.is_empty() {
+        return Ok(AiExecutionResult {
+            success: false,
+            output: String::new(),
+            error: Some("Ollama returned empty output. Please try again.".to_string()),
+        });
+    }
+
+    tokio::fs::write(&canonical, edited_content.as_bytes())
+        .await
+        .map_err(|e| format!("Failed to write edited file: {}", e))?;
+
+    Ok(AiExecutionResult {
+        success: true,
+        output: "Note edited successfully with Ollama.".to_string(),
+        error: None,
+    })
 }
 
 /// Check if a markdown file is inside the configured notes folder.


### PR DESCRIPTION
Fixes #143.

## Root cause

`ai_execute_ollama` shelled out to `ollama run <model>`, piping the prompt via stdin and capturing stdout as plain text.

Ollama's own CLI (`cmd/cmd.go`) has a flag-precedence quirk: it correctly detects piped/non-interactive stdin and sets `opts.WordWrap = false`, but a few lines later unconditionally re-derives `opts.WordWrap = !nowrap` from the `--nowordwrap` flag's default value, silently re-enabling word-wrap rendering even when piped.

With word-wrap on, Ollama's `displayResponse` renderer prints a word's characters as they stream in, and if the word would cross the (assumed 80-column) line boundary, it erases the partial word with an ANSI cursor-back + erase-in-line sequence and reprints it whole on the next line. On a real terminal this looks like clean wrapping. Scratch only stripped well-formed ANSI escape codes via regex — which deletes the control bytes but not the characters already printed before them — so the "erased" partial word survives in the captured text, immediately followed by the full word: `founda` + `foundational`, exactly matching the reports in this issue.

## Fix

Switch `ai_execute_ollama` to `POST http://localhost:11434/api/generate` directly (`stream: false`, `think: true`) instead of spawning a subprocess. No terminal rendering is involved at all, so there's nothing to strip or repair.

As a side benefit, Ollama returns `response` and `thinking` as separate JSON fields (confirmed against its `GenerateResponse` struct), so enabling thinking no longer risks it leaking into note content — only `response` is ever written to the file. This also let us drop the separate `ollama show` pre-check subprocess (a 404 from `/api/generate` now drives the "model not found" message directly) and the CLI-stderr string matching, in favor of real HTTP status codes and Ollama's structured `{"error": "..."}` body.

## Testing

- `cargo check` and `cargo clippy -- -D warnings` pass clean.
- Manually verified against a running local Ollama instance: multi-line generation/edits no longer duplicate or truncate words at line boundaries, and reasoning models (`think: true`) no longer mix `<think>` content into the saved note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editing requests now connect directly to the local Ollama service.
  * Supports model selection, generated Markdown output, and clearer handling of connection, authentication, and missing-model errors.

* **Bug Fixes**
  * Prevents empty generated content from overwriting files.
  * Ensures supplementary thinking output is excluded from saved edits.
  * Adds timeout handling for requests that take too long.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->