### PR TITLE
Add editor display and title-bar settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,9 +56,11 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "happy-dom": "20.11.1",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "vitest": "4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1981,6 +1983,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -3239,6 +3248,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3276,6 +3303,16 @@
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -3305,6 +3342,23 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3326,6 +3380,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3342,6 +3509,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -3411,6 +3588,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001776",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
@@ -3431,6 +3621,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -3574,6 +3774,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -3636,6 +3843,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-equals": {
@@ -3705,6 +3932,38 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/happy-dom": {
+      "version": "20.11.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.1.tgz",
+      "integrity": "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/highlight.js": {
       "version": "11.11.1",
@@ -4151,10 +4410,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/orderedmap": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -4601,6 +4881,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -4620,6 +4907,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -4652,6 +4953,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4667,6 +4985,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tippy.js": {
@@ -4702,6 +5030,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4869,11 +5204,150 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -58,8 +60,10 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "happy-dom": "20.11.1",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "4.1.10"
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -129,6 +129,8 @@ pub struct Settings {
     pub ollama_model: Option<String>,
     #[serde(rename = "foldersEnabled")]
     pub folders_enabled: Option<bool>,
+    #[serde(rename = "sidebarSortOrder")]
+    pub sidebar_sort_order: Option<String>,
     #[serde(rename = "ignoredPatterns")]
     pub ignored_patterns: Option<Vec<String>>,
     #[serde(rename = "customColorsLight")]
@@ -3993,4 +3995,22 @@ fn set_title_bar_theme(
         let _ = (app, is_dark, r, g, b);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Settings;
+
+    #[test]
+    fn settings_preserve_sidebar_note_sort_order() {
+        let settings: Settings = serde_json::from_str(
+            r#"{"theme":{"mode":"system"},"sidebarSortOrder":"oldest"}"#,
+        )
+        .expect("settings should deserialize");
+
+        assert_eq!(settings.sidebar_sort_order.as_deref(), Some("oldest"));
+
+        let serialized = serde_json::to_value(settings).expect("settings should serialize");
+        assert_eq!(serialized["sidebarSortOrder"], "oldest");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,6 +122,14 @@ pub struct Settings {
     pub interface_zoom: Option<f32>,
     #[serde(rename = "customEditorWidthPx")]
     pub custom_editor_width_px: Option<u32>,
+    #[serde(rename = "editorWidthResizeEnabled")]
+    pub editor_width_resize_enabled: Option<bool>,
+    #[serde(rename = "editorToolbarVisible")]
+    pub editor_toolbar_visible: Option<bool>,
+    #[serde(rename = "titleBarModifiedDateVisible")]
+    pub title_bar_modified_date_visible: Option<bool>,
+    #[serde(rename = "titleBarFilenameVisible")]
+    pub title_bar_filename_visible: Option<bool>,
     /// Custom sidebar width in px; `None` means the default width is used.
     #[serde(rename = "sidebarWidthPx")]
     pub sidebar_width_px: Option<u32>,
@@ -4012,5 +4020,30 @@ mod tests {
 
         let serialized = serde_json::to_value(settings).expect("settings should serialize");
         assert_eq!(serialized["sidebarSortOrder"], "oldest");
+    }
+
+    #[test]
+    fn settings_preserve_editor_display_preferences() {
+        let settings: Settings = serde_json::from_str(
+            r#"{
+                "theme":{"mode":"system"},
+                "editorWidthResizeEnabled":false,
+                "editorToolbarVisible":true,
+                "titleBarModifiedDateVisible":false,
+                "titleBarFilenameVisible":true
+            }"#,
+        )
+        .expect("settings should deserialize");
+
+        assert_eq!(settings.editor_width_resize_enabled, Some(false));
+        assert_eq!(settings.editor_toolbar_visible, Some(true));
+        assert_eq!(settings.title_bar_modified_date_visible, Some(false));
+        assert_eq!(settings.title_bar_filename_visible, Some(true));
+
+        let serialized = serde_json::to_value(settings).expect("settings should serialize");
+        assert_eq!(serialized["editorWidthResizeEnabled"], false);
+        assert_eq!(serialized["editorToolbarVisible"], true);
+        assert_eq!(serialized["titleBarModifiedDateVisible"], false);
+        assert_eq!(serialized["titleBarFilenameVisible"], true);
     }
 }

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -71,6 +71,7 @@ import { EditorWidthHandles } from "./EditorWidthHandle";
 import { ScratchBlockMath, normalizeBlockMath } from "./MathExtensions";
 import { cn } from "../../lib/utils";
 import { plainTextFromMarkdown } from "../../lib/plainText";
+import { getTitleBarNoteInfoText } from "../../lib/titleBarNoteInfo";
 import { Button, IconButton, ToolbarButton, Tooltip } from "../ui";
 import * as notesService from "../../services/notes";
 import { downloadPdf, downloadMarkdown } from "../../services/pdf";
@@ -546,12 +547,28 @@ export function Editor({
   const pinNote = notesCtx?.pinNote;
   const unpinNote = notesCtx?.unpinNote;
   const notes = notesCtx?.notes;
-  const { textDirection } = useTheme();
+  const {
+    textDirection,
+    editorWidthResizeEnabled,
+    editorToolbarVisible,
+    titleBarModifiedDateVisible,
+    titleBarFilenameVisible,
+  } = useTheme();
   const [isSaving, setIsSaving] = useState(false);
   // Force re-render when selection changes to update toolbar active states
   const [, setSelectionKey] = useState(0);
   const [copyMenuOpen, setCopyMenuOpen] = useState(false);
   const [settings, setSettings] = useState<Settings | null>(null);
+  const titleBarNoteInfo = currentNote
+    ? getTitleBarNoteInfoText(
+        {
+          modifiedDateVisible: titleBarModifiedDateVisible,
+          filenameVisible: titleBarFilenameVisible,
+        },
+        currentNote,
+        formatDateTime,
+      )
+    : null;
   // Delay transition classes until after initial mount to avoid format bar height animation on note load
   const [hasTransitioned, setHasTransitioned] = useState(false);
   useEffect(() => {
@@ -2257,9 +2274,11 @@ export function Editor({
               <PanelLeftIcon className="w-4.5 h-4.5 stroke-[1.5]" />
             </IconButton>
           )}
-          <span className="text-xs text-text-muted mb-px truncate">
-            {formatDateTime(currentNote.modified)}
-          </span>
+          {titleBarNoteInfo && (
+            <span className="text-xs text-text-muted mb-px truncate">
+              {titleBarNoteInfo}
+            </span>
+          )}
         </div>
         <div
           className={`titlebar-no-drag flex items-center gap-px shrink-0 transition-opacity duration-400 ${needsSidebarDelay ? "delay-200" : ""} ${focusMode ? "opacity-0 pointer-events-none" : "opacity-100"}`}
@@ -2432,22 +2451,27 @@ export function Editor({
       </div>
 
       {/* Format Bar – transition only after initial mount to avoid height animation on note load */}
-      <div
-        data-format-bar
-        className={`${focusMode || sourceMode ? "opacity-0 max-h-0 overflow-hidden pointer-events-none" : "opacity-100 max-h-20"} ${hasTransitioned ? `transition-all duration-400 ${needsSidebarDelay ? "delay-200" : ""}` : ""}`}
-      >
-        <FormatBar
-          editor={editor}
-          onAddLink={handleAddLink}
-          onAddBlockMath={handleAddBlockMath}
-          onAddImage={handleAddImage}
-        />
-      </div>
+      {editorToolbarVisible && (
+        <div
+          data-format-bar
+          className={`${focusMode || sourceMode ? "opacity-0 max-h-0 overflow-hidden pointer-events-none" : "opacity-100 max-h-20"} ${hasTransitioned ? `transition-all duration-400 ${needsSidebarDelay ? "delay-200" : ""}` : ""}`}
+        >
+          <FormatBar
+            editor={editor}
+            onAddLink={handleAddLink}
+            onAddBlockMath={handleAddBlockMath}
+            onAddImage={handleAddImage}
+          />
+        </div>
+      )}
 
       {/* Editor content area with resize handles overlay */}
       <div data-editor-content-area className="flex-1 relative overflow-hidden">
         {!focusMode && !sourceMode && (
-          <EditorWidthHandles containerRef={scrollContainerRef} />
+          <EditorWidthHandles
+            containerRef={scrollContainerRef}
+            enabled={editorWidthResizeEnabled}
+          />
         )}
         <div
           data-editor-scroll

--- a/src/components/editor/EditorWidthHandle.test.tsx
+++ b/src/components/editor/EditorWidthHandle.test.tsx
@@ -1,10 +1,20 @@
 import { act, createRef } from "react";
 import { createRoot } from "react-dom/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   EditorWidthHandles,
   getRenderedEditorWidth,
 } from "./EditorWidthHandle";
+
+vi.mock("../../context/ThemeContext", () => ({
+  useTheme: () => ({
+    editorWidth: "normal",
+    customEditorWidthPx: 768,
+    setEditorWidth: vi.fn(),
+    setCustomEditorWidthPx: vi.fn(),
+    setEditorMaxWidthLive: vi.fn(),
+  }),
+}));
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
   .IS_REACT_ACT_ENVIRONMENT = true;
@@ -32,6 +42,27 @@ describe("EditorWidthHandles", () => {
     expect(getRenderedEditorWidth(container)).toBe(526);
   });
 
+  it("caps the measured width at the container width", () => {
+    const container = document.createElement("div");
+    const editor = document.createElement("div");
+    editor.className = "ProseMirror";
+    editor.getBoundingClientRect = () => ({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 700,
+      bottom: 800,
+      width: 700,
+      height: 800,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(container, "clientWidth", { value: 600 });
+    container.append(editor);
+
+    expect(getRenderedEditorWidth(container)).toBe(600);
+  });
+
   it("mounts no resize interaction when mouse resizing is disabled", () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -50,5 +81,56 @@ describe("EditorWidthHandles", () => {
 
     act(() => root.unmount());
     container.remove();
+  });
+
+  it("mounts both resize handles when mouse resizing is enabled", () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    const editorContainer = document.createElement("div");
+    const editor = document.createElement("div");
+    editor.className = "ProseMirror";
+    editor.getBoundingClientRect = () => ({
+      x: 216,
+      y: 0,
+      left: 216,
+      top: 0,
+      right: 984,
+      bottom: 800,
+      width: 768,
+      height: 800,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(editorContainer, "clientWidth", { value: 1200 });
+    editorContainer.append(editor);
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <EditorWidthHandles
+          enabled
+          containerRef={{ current: editorContainer }}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll('[role="separator"]')).toHaveLength(2);
+    expect(
+      container.querySelector('[aria-label="Resize editor width (left)"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Resize editor width (right)"]'),
+    ).not.toBeNull();
+
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
   });
 });

--- a/src/components/editor/EditorWidthHandle.test.tsx
+++ b/src/components/editor/EditorWidthHandle.test.tsx
@@ -1,0 +1,54 @@
+import { act, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it } from "vitest";
+import {
+  EditorWidthHandles,
+  getRenderedEditorWidth,
+} from "./EditorWidthHandle";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("EditorWidthHandles", () => {
+  it("measures the rendered page instead of its unconstrained max-width", () => {
+    const container = document.createElement("div");
+    const editor = document.createElement("div");
+    editor.className = "ProseMirror";
+    editor.style.maxWidth = "576px";
+    editor.getBoundingClientRect = () => ({
+      x: 37,
+      y: 0,
+      left: 37,
+      top: 0,
+      right: 563,
+      bottom: 800,
+      width: 526,
+      height: 800,
+      toJSON: () => ({}),
+    });
+    Object.defineProperty(container, "clientWidth", { value: 600 });
+    container.append(editor);
+
+    expect(getRenderedEditorWidth(container)).toBe(526);
+  });
+
+  it("mounts no resize interaction when mouse resizing is disabled", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <EditorWidthHandles
+          enabled={false}
+          containerRef={createRef<HTMLDivElement>()}
+        />,
+      );
+    });
+
+    expect(container.childElementCount).toBe(0);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/src/components/editor/EditorWidthHandle.tsx
+++ b/src/components/editor/EditorWidthHandle.tsx
@@ -21,9 +21,33 @@ const SNAP_THRESHOLD = 20;
 
 interface EditorWidthHandlesProps {
   containerRef: RefObject<HTMLDivElement | null>;
+  enabled: boolean;
 }
 
-export function EditorWidthHandles({ containerRef }: EditorWidthHandlesProps) {
+export function getRenderedEditorWidth(
+  container: HTMLDivElement,
+): number | null {
+  const proseMirror = container.querySelector<HTMLElement>(".ProseMirror");
+  if (!proseMirror) return null;
+
+  const renderedWidth = proseMirror.getBoundingClientRect().width;
+  if (!Number.isFinite(renderedWidth) || renderedWidth <= 0) return null;
+
+  return Math.min(renderedWidth, container.clientWidth);
+}
+
+export function EditorWidthHandles({
+  containerRef,
+  enabled,
+}: EditorWidthHandlesProps) {
+  if (!enabled) return null;
+
+  return <ActiveEditorWidthHandles containerRef={containerRef} />;
+}
+
+function ActiveEditorWidthHandles({
+  containerRef,
+}: Pick<EditorWidthHandlesProps, "containerRef">) {
   const {
     editorWidth,
     customEditorWidthPx,
@@ -48,17 +72,10 @@ export function EditorWidthHandles({ containerRef }: EditorWidthHandlesProps) {
   const updateHandleOffset = useCallback(() => {
     if (!containerRef.current) return;
     const containerWidth = containerRef.current.clientWidth;
-    const proseMirror =
-      containerRef.current.querySelector<HTMLElement>(".ProseMirror");
-    if (proseMirror) {
-      const maxWidth = getComputedStyle(proseMirror).maxWidth;
-      if (maxWidth && maxWidth !== "none") {
-        const editorPx =
-          maxWidth === "100%" ? containerWidth : parseFloat(maxWidth);
-        const clampedEditor = Math.min(editorPx, containerWidth);
-        setHandleOffset((containerWidth - clampedEditor) / 2);
-        return;
-      }
+    const renderedWidth = getRenderedEditorWidth(containerRef.current);
+    if (renderedWidth !== null) {
+      setHandleOffset((containerWidth - renderedWidth) / 2);
+      return;
     }
     setHandleOffset(0);
   }, [containerRef]);
@@ -75,13 +92,8 @@ export function EditorWidthHandles({ containerRef }: EditorWidthHandlesProps) {
 
   const getCurrentEditorWidth = useCallback((): number => {
     if (!containerRef.current) return 768;
-    const proseMirror = containerRef.current.querySelector(".ProseMirror");
-    if (proseMirror) {
-      const maxWidth = getComputedStyle(proseMirror).maxWidth;
-      if (maxWidth && maxWidth !== "none" && maxWidth !== "100%") {
-        return parseFloat(maxWidth);
-      }
-    }
+    const renderedWidth = getRenderedEditorWidth(containerRef.current);
+    if (renderedWidth !== null) return renderedWidth;
     if (editorWidth === "custom") return customEditorWidthPx;
     if (editorWidth === "full") return containerRef.current.clientWidth;
     const preset = PRESET_PX.find((p) => p.width === editorWidth);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -26,6 +26,8 @@ import {
 import { mod, shift, isMac, isWindows } from "../../lib/platform";
 import * as notesService from "../../services/notes";
 import { FolderNameDialog } from "../notes/FolderNameDialog";
+import { NoteSortMenu } from "./SidebarControls";
+import type { NoteSortOrder } from "../../types/note";
 
 interface SidebarProps {
   onOpenSettings?: () => void;
@@ -49,6 +51,8 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
   const [folderDialogOpen, setFolderDialogOpen] = useState(false);
   const [folderDialogParent, setFolderDialogParent] = useState("");
   const [foldersEnabled, setFoldersEnabled] = useState(true);
+  const [noteSortOrder, setNoteSortOrder] =
+    useState<NoteSortOrder>("newest");
   const [dragLabel, setDragLabel] = useState<string | null>(null);
   const [dragCount, setDragCount] = useState(1);
   const [multiSelectedNoteIds, setMultiSelectedNoteIds] = useState<Set<string>>(new Set());
@@ -169,11 +173,40 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
   useEffect(() => {
     notesService.getSettings().then((s) => {
       setFoldersEnabled(s.foldersEnabled === true);
+      setNoteSortOrder(
+        s.sidebarSortOrder === "oldest" ? "oldest" : "newest",
+      );
     }).catch((error) => {
       console.error("Failed to load settings:", error);
       setFoldersEnabled(false);
     });
   }, []);
+
+  const handleNoteSortOrderChange = useCallback(
+    (nextSortOrder: NoteSortOrder) => {
+      if (nextSortOrder === noteSortOrder) return;
+
+      const previousSortOrder = noteSortOrder;
+      setNoteSortOrder(nextSortOrder);
+
+      void notesService
+        .getSettings()
+        .then((settings) =>
+          notesService.updateSettings({
+            ...settings,
+            sidebarSortOrder: nextSortOrder,
+          }),
+        )
+        .catch((error) => {
+          console.error("Failed to save note sort order:", error);
+          setNoteSortOrder((current) =>
+            current === nextSortOrder ? previousSortOrder : current,
+          );
+          toast.error("Failed to save note sort order");
+        });
+    },
+    [noteSortOrder],
+  );
 
   // Sync input with search query
   useEffect(() => {
@@ -321,6 +354,10 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
           </div>
         </div>
         <div className="flex items-center gap-px">
+          <NoteSortMenu
+            sortOrder={noteSortOrder}
+            onChange={handleNoteSortOrderChange}
+          />
           <IconButton
             onClick={toggleSearch}
             title={`Search Notes (${mod}${isMac ? "" : "+"}${shift}${isMac ? "" : "+"}F)`}
@@ -413,6 +450,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
 
         {/* Note list */}
         <NoteList
+          sortOrder={noteSortOrder}
           multiSelectedNoteIds={multiSelectedNoteIds}
           setMultiSelectedNoteIds={setMultiSelectedNoteIds}
           lastClickedNoteId={lastClickedNoteId}

--- a/src/components/layout/SidebarControls.test.tsx
+++ b/src/components/layout/SidebarControls.test.tsx
@@ -1,0 +1,65 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "../ui";
+import {
+  NoteSortMenu,
+} from "./SidebarControls";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("NoteSortMenu", () => {
+  it("offers newest and oldest ordering and reports the selected option", () => {
+    const onChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <NoteSortMenu sortOrder="newest" onChange={onChange} />
+        </TooltipProvider>,
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Sort notes: Newest first"]',
+    );
+    expect(trigger).not.toBeNull();
+    expect(trigger?.tabIndex).toBe(0);
+
+    act(() => {
+      trigger?.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          button: 0,
+          pointerType: "mouse",
+        }),
+      );
+    });
+
+    const options = Array.from(
+      document.body.querySelectorAll<HTMLElement>('[role="menuitemradio"]'),
+    );
+    expect(options.map((option) => option.textContent?.trim())).toEqual([
+      "Newest first",
+      "Oldest first",
+    ]);
+    expect(options[0]?.getAttribute("aria-checked")).toBe("true");
+
+    act(() => {
+      options[1]?.click();
+    });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("oldest");
+
+    act(() => root.unmount());
+  });
+});

--- a/src/components/layout/SidebarControls.tsx
+++ b/src/components/layout/SidebarControls.tsx
@@ -1,0 +1,74 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import type { NoteSortOrder } from "../../types/note";
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CheckIcon,
+} from "../icons";
+import { IconButton } from "../ui";
+
+interface NoteSortMenuProps {
+  sortOrder: NoteSortOrder;
+  onChange: (sortOrder: NoteSortOrder) => void;
+}
+
+const radioItemClass =
+  "relative flex cursor-pointer items-center gap-2 px-3 py-1.5 pr-8 text-sm text-text outline-none hover:bg-bg-muted focus:bg-bg-muted data-[state=checked]:font-medium";
+
+export function NoteSortMenu({
+  sortOrder,
+  onChange,
+}: NoteSortMenuProps) {
+  const newestFirst = sortOrder === "newest";
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <IconButton
+          title={`Sort notes: ${newestFirst ? "Newest" : "Oldest"} first`}
+          tabIndex={0}
+          className="active:scale-[0.96] motion-reduce:transform-none"
+        >
+          {newestFirst ? (
+            <ArrowDownIcon className="h-4.25 w-4.25 stroke-[1.5]" />
+          ) : (
+            <ArrowUpIcon className="h-4.25 w-4.25 stroke-[1.5]" />
+          )}
+        </IconButton>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          className="z-50 min-w-44 rounded-md border border-border bg-bg py-1 shadow-lg"
+          sideOffset={5}
+          align="end"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+        >
+          <DropdownMenu.Label className="px-3 py-1 text-xs font-medium text-text-muted">
+            Sort notes
+          </DropdownMenu.Label>
+          <DropdownMenu.RadioGroup
+            value={sortOrder}
+            onValueChange={(value) => {
+              if (value === "newest" || value === "oldest") onChange(value);
+            }}
+          >
+            <DropdownMenu.RadioItem value="newest" className={radioItemClass}>
+              <ArrowDownIcon className="h-4 w-4 shrink-0 stroke-[1.6]" />
+              Newest first
+              <DropdownMenu.ItemIndicator className="absolute right-3 inline-flex items-center">
+                <CheckIcon className="h-3.5 w-3.5 stroke-[1.8]" />
+              </DropdownMenu.ItemIndicator>
+            </DropdownMenu.RadioItem>
+            <DropdownMenu.RadioItem value="oldest" className={radioItemClass}>
+              <ArrowUpIcon className="h-4 w-4 shrink-0 stroke-[1.6]" />
+              Oldest first
+              <DropdownMenu.ItemIndicator className="absolute right-3 inline-flex items-center">
+                <CheckIcon className="h-3.5 w-3.5 stroke-[1.8]" />
+              </DropdownMenu.ItemIndicator>
+            </DropdownMenu.RadioItem>
+          </DropdownMenu.RadioGroup>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}

--- a/src/components/layout/SidebarControls.tsx
+++ b/src/components/layout/SidebarControls.tsx
@@ -41,7 +41,6 @@ export function NoteSortMenu({
           className="z-50 min-w-44 rounded-md border border-border bg-bg py-1 shadow-lg"
           sideOffset={5}
           align="end"
-          onCloseAutoFocus={(event) => event.preventDefault()}
         >
           <DropdownMenu.Label className="px-3 py-1 text-xs font-medium text-text-muted">
             Sort notes

--- a/src/components/layout/SidebarFolderSection.test.tsx
+++ b/src/components/layout/SidebarFolderSection.test.tsx
@@ -1,0 +1,84 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SidebarFolderSection,
+  loadFolderSectionCollapsed,
+  saveFolderSectionCollapsed,
+} from "./SidebarFolderSection";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("folder section persistence", () => {
+  it("loads only an explicitly collapsed section and saves the next state", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    expect(loadFolderSectionCollapsed(storage)).toBe(false);
+    values.set("scratch:foldersSectionCollapsed", "true");
+    expect(loadFolderSectionCollapsed(storage)).toBe(true);
+
+    saveFolderSectionCollapsed(false, storage);
+    expect(values.get("scratch:foldersSectionCollapsed")).toBe("false");
+  });
+});
+
+describe("SidebarFolderSection", () => {
+  it("uses one disclosure control to hide and reveal the complete folder group", () => {
+    const onCollapsedChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SidebarFolderSection
+          collapsed={false}
+          onCollapsedChange={onCollapsedChange}
+        >
+          <div data-testid="folder-group">Folder tree</div>
+        </SidebarFolderSection>,
+      );
+    });
+
+    const collapseButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse Folders"]',
+    );
+    expect(collapseButton?.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("Folders");
+    expect(container.querySelector('[data-testid="folder-group"]')).not.toBeNull();
+
+    act(() => collapseButton?.click());
+    expect(onCollapsedChange).toHaveBeenCalledWith(true);
+
+    act(() => {
+      root.render(
+        <SidebarFolderSection
+          collapsed
+          onCollapsedChange={onCollapsedChange}
+        >
+          <div data-testid="folder-group">Folder tree</div>
+        </SidebarFolderSection>,
+      );
+    });
+
+    const expandButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Expand Folders"]',
+    );
+    expect(expandButton?.getAttribute("aria-expanded")).toBe("false");
+    expect(container.querySelector('[data-testid="folder-group"]')).toBeNull();
+
+    act(() => expandButton?.click());
+    expect(onCollapsedChange).toHaveBeenLastCalledWith(false);
+
+    act(() => root.unmount());
+  });
+});

--- a/src/components/layout/SidebarFolderSection.tsx
+++ b/src/components/layout/SidebarFolderSection.tsx
@@ -1,0 +1,72 @@
+import { useId, type ReactNode } from "react";
+import { ChevronRightIcon } from "../icons";
+
+const STORAGE_KEY = "scratch:foldersSectionCollapsed";
+
+type SidebarStorage = Pick<Storage, "getItem" | "setItem">;
+
+function defaultStorage(): SidebarStorage | undefined {
+  try {
+    return globalThis.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function loadFolderSectionCollapsed(
+  storage: SidebarStorage | undefined = defaultStorage(),
+): boolean {
+  try {
+    return storage?.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function saveFolderSectionCollapsed(
+  collapsed: boolean,
+  storage: SidebarStorage | undefined = defaultStorage(),
+): void {
+  try {
+    storage?.setItem(STORAGE_KEY, String(collapsed));
+  } catch {
+    // Keep the disclosure usable when storage is unavailable.
+  }
+}
+
+interface SidebarFolderSectionProps {
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
+  children: ReactNode;
+}
+
+export function SidebarFolderSection({
+  collapsed,
+  onCollapsedChange,
+  children,
+}: SidebarFolderSectionProps) {
+  const contentId = useId();
+  const expanded = !collapsed;
+
+  return (
+    <section aria-label="Folders" className="flex flex-col gap-0.5">
+      <button
+        type="button"
+        aria-label={`${expanded ? "Collapse" : "Expand"} Folders`}
+        aria-expanded={expanded}
+        aria-controls={contentId}
+        onClick={() => onCollapsedChange(!collapsed)}
+        className="flex h-8 w-full shrink-0 items-center gap-1 rounded-sm px-2 text-left text-xs font-medium text-text-muted outline-none transition-colors hover:bg-bg-muted hover:text-text focus-visible:bg-bg-muted focus-visible:text-text active:bg-bg-muted motion-reduce:transition-none"
+      >
+        <span>Folders</span>
+        <ChevronRightIcon
+          aria-hidden="true"
+          className={`h-3.5 w-3.5 shrink-0 stroke-[1.7] transition-transform duration-150 motion-reduce:transition-none${
+            expanded ? " rotate-90" : ""
+          }`}
+        />
+      </button>
+      {expanded && <div id={contentId}>{children}</div>}
+    </section>
+  );
+}

--- a/src/components/notes/FolderTreeView.test.tsx
+++ b/src/components/notes/FolderTreeView.test.tsx
@@ -1,0 +1,67 @@
+import { DndContext } from "@dnd-kit/core";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import type { FolderNode } from "../../types/note";
+import { FolderItemComponent } from "./FolderTreeView";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("FolderItemComponent", () => {
+  it("does not expose a per-folder descendant-collapse action", () => {
+    const child: FolderNode = {
+      name: "docs",
+      path: "Point/docs",
+      children: [],
+      notes: [],
+    };
+    const parent: FolderNode = {
+      name: "Point",
+      path: "Point",
+      children: [child],
+      notes: [],
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <DndContext>
+          <FolderItemComponent
+            folder={parent}
+            depth={0}
+            collapsedFolders={new Set()}
+            onToggleCollapse={vi.fn()}
+            selectedNoteId={null}
+            pinnedIds={new Set()}
+            multiSelectedNoteIds={new Set()}
+            onNoteClick={vi.fn()}
+            focusedItemKey={null}
+            onCreateNoteHere={vi.fn()}
+            onNewSubfolder={vi.fn()}
+            onRenameFolder={vi.fn()}
+            onDeleteFolder={vi.fn()}
+            onPinNote={vi.fn(async () => undefined)}
+            onUnpinNote={vi.fn(async () => undefined)}
+            onDuplicateNote={vi.fn(async () => undefined)}
+            onDeleteNote={vi.fn()}
+            onMoveNoteToParent={vi.fn()}
+            onMoveFolderToParent={vi.fn()}
+          />
+        </DndContext>,
+      );
+    });
+
+    expect(
+      container.querySelector(
+        'button[aria-label="Collapse all subfolders in Point"]',
+      ),
+    ).toBeNull();
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/src/components/notes/FolderTreeView.tsx
+++ b/src/components/notes/FolderTreeView.tsx
@@ -5,7 +5,7 @@ import { useNotes } from "../../context/NotesContext";
 import {
   buildFolderTree,
   countNotesInFolder,
-  getVisibleItems,
+  getVisibleItemsForFolderSection,
   type TreeItem,
 } from "../../lib/folderTree";
 import { FolderNameDialog } from "./FolderNameDialog";
@@ -35,7 +35,17 @@ import {
   ArrowUpIcon,
 } from "../icons";
 import * as notesService from "../../services/notes";
-import type { FolderNode, NoteMetadata, Settings } from "../../types/note";
+import {
+  SidebarFolderSection,
+  loadFolderSectionCollapsed,
+  saveFolderSectionCollapsed,
+} from "../layout/SidebarFolderSection";
+import type {
+  FolderNode,
+  NoteMetadata,
+  NoteSortOrder,
+  Settings,
+} from "../../types/note";
 
 const STORAGE_KEY = "scratch:collapsedFolders";
 
@@ -269,7 +279,7 @@ interface FolderItemProps {
   onMoveFolderToParent: (path: string, targetParent: string) => void;
 }
 
-const FolderItemComponent = memo(function FolderItem({
+export const FolderItemComponent = memo(function FolderItem({
   folder,
   depth,
   collapsedFolders,
@@ -474,6 +484,7 @@ const FolderItemComponent = memo(function FolderItem({
 });
 
 interface FolderTreeViewProps {
+  sortOrder: NoteSortOrder;
   pinnedIds: Set<string>;
   settings: Settings | null;
   multiSelectedNoteIds: Set<string>;
@@ -483,6 +494,7 @@ interface FolderTreeViewProps {
 }
 
 export function FolderTreeView({
+  sortOrder,
   pinnedIds,
   settings: _settings,
   multiSelectedNoteIds,
@@ -508,6 +520,9 @@ export function FolderTreeView({
 
   const [collapsedFolders, setCollapsedFolders] =
     useState<Set<string>>(loadCollapsedFolders);
+  const [foldersSectionCollapsed, setFoldersSectionCollapsed] = useState(
+    loadFolderSectionCollapsed,
+  );
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [folderToDelete, setFolderToDelete] = useState<string | null>(null);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
@@ -534,9 +549,13 @@ export function FolderTreeView({
     saveCollapsedFolders(collapsedFolders);
   }, [collapsedFolders]);
 
+  useEffect(() => {
+    saveFolderSectionCollapsed(foldersSectionCollapsed);
+  }, [foldersSectionCollapsed]);
+
   const tree = useMemo(
-    () => buildFolderTree(notes, pinnedIds, knownFolders),
-    [notes, pinnedIds, knownFolders],
+    () => buildFolderTree(notes, pinnedIds, knownFolders, sortOrder),
+    [notes, pinnedIds, knownFolders, sortOrder],
   );
 
   const handleToggleCollapse = useCallback((path: string) => {
@@ -554,6 +573,7 @@ export function FolderTreeView({
   // Expand a folder and all its ancestors
   const expandFolder = useCallback((folderPath: string) => {
     if (!folderPath) return;
+    setFoldersSectionCollapsed(false);
     setCollapsedFolders((prev) => {
       const next = new Set(prev);
       // Expand this folder and every ancestor
@@ -663,8 +683,14 @@ export function FolderTreeView({
 
   // Flat list of visible items for keyboard navigation
   const visibleItems = useMemo(
-    () => getVisibleItems(tree, pinnedIds, collapsedFolders),
-    [tree, pinnedIds, collapsedFolders],
+    () =>
+      getVisibleItemsForFolderSection(
+        tree,
+        pinnedIds,
+        collapsedFolders,
+        foldersSectionCollapsed,
+      ),
+    [tree, pinnedIds, collapsedFolders, foldersSectionCollapsed],
   );
 
   // Visible note IDs in order (for Shift+Click range computation)
@@ -875,30 +901,37 @@ export function FolderTreeView({
         ))}
 
         {/* Folders */}
-        {tree.folders.map((folder) => (
-          <FolderItemComponent
-            key={folder.path}
-            folder={folder}
-            depth={0}
-            collapsedFolders={collapsedFolders}
-            onToggleCollapse={handleToggleCollapse}
-            selectedNoteId={selectedNoteId}
-            focusedItemKey={focusedItemKey}
-            pinnedIds={pinnedIds}
-            multiSelectedNoteIds={multiSelectedNoteIds}
-            onNoteClick={handleNoteClick}
-            onCreateNoteHere={createNoteInFolder}
-            onNewSubfolder={handleNewSubfolder}
-            onRenameFolder={handleRenameFolder}
-            onDeleteFolder={handleDeleteFolder}
-            onPinNote={pinNote}
-            onUnpinNote={unpinNote}
-            onDuplicateNote={duplicateNote}
-            onDeleteNote={openDeleteNoteDialog}
-            onMoveNoteToParent={moveNote}
-            onMoveFolderToParent={moveFolder}
-          />
-        ))}
+        {tree.folders.length > 0 && (
+          <SidebarFolderSection
+            collapsed={foldersSectionCollapsed}
+            onCollapsedChange={setFoldersSectionCollapsed}
+          >
+            {tree.folders.map((folder) => (
+              <FolderItemComponent
+                key={folder.path}
+                folder={folder}
+                depth={0}
+                collapsedFolders={collapsedFolders}
+                onToggleCollapse={handleToggleCollapse}
+                selectedNoteId={selectedNoteId}
+                focusedItemKey={focusedItemKey}
+                pinnedIds={pinnedIds}
+                multiSelectedNoteIds={multiSelectedNoteIds}
+                onNoteClick={handleNoteClick}
+                onCreateNoteHere={createNoteInFolder}
+                onNewSubfolder={handleNewSubfolder}
+                onRenameFolder={handleRenameFolder}
+                onDeleteFolder={handleDeleteFolder}
+                onPinNote={pinNote}
+                onUnpinNote={unpinNote}
+                onDuplicateNote={duplicateNote}
+                onDeleteNote={openDeleteNoteDialog}
+                onMoveNoteToParent={moveNote}
+                onMoveFolderToParent={moveFolder}
+              />
+            ))}
+          </SidebarFolderSection>
+        )}
 
         {/* Unpinned root notes */}
         {unpinnedRootNotes.map((note) => (

--- a/src/components/notes/NoteList.tsx
+++ b/src/components/notes/NoteList.tsx
@@ -21,7 +21,8 @@ import {
   CopyIcon,
   TrashIcon,
 } from "../icons";
-import type { Settings } from "../../types/note";
+import type { NoteSortOrder, Settings } from "../../types/note";
+import { sortNotesByModified } from "../../lib/folderTree";
 
 const menuItemClass =
   "px-3 py-1.5 text-sm text-text cursor-pointer outline-none hover:bg-bg-muted focus:bg-bg-muted flex items-center gap-2 rounded-sm";
@@ -227,6 +228,7 @@ const NoteItemWithMenu = memo(function NoteItemWithMenu({
 });
 
 interface NoteListProps {
+  sortOrder: NoteSortOrder;
   multiSelectedNoteIds: Set<string>;
   setMultiSelectedNoteIds: React.Dispatch<React.SetStateAction<Set<string>>>;
   lastClickedNoteId: string | null;
@@ -234,6 +236,7 @@ interface NoteListProps {
 }
 
 export function NoteList({
+  sortOrder,
   multiSelectedNoteIds,
   setMultiSelectedNoteIds,
   lastClickedNoteId,
@@ -307,6 +310,11 @@ export function NoteList({
     return notes;
   }, [searchQuery, searchResults, notes]);
 
+  const sortedDisplayItems = useMemo(
+    () => sortNotesByModified(displayItems, sortOrder),
+    [displayItems, sortOrder],
+  );
+
   // Listen for focus request from editor (when Escape is pressed)
   useEffect(() => {
     const handleFocusNoteList = () => {
@@ -341,7 +349,7 @@ export function NoteList({
     );
   }
 
-  if (isSearching && displayItems.length === 0) {
+  if (isSearching && sortedDisplayItems.length === 0) {
     return (
       <div className="p-4 text-center text-sm text-text-muted select-none">
         No results found
@@ -349,7 +357,7 @@ export function NoteList({
     );
   }
 
-  if (displayItems.length === 0) {
+  if (sortedDisplayItems.length === 0) {
     return (
       <div className="p-4 text-center text-sm text-text-muted select-none">
         No notes yet
@@ -362,6 +370,7 @@ export function NoteList({
     return (
       <>
         <FolderTreeView
+          sortOrder={sortOrder}
           pinnedIds={pinnedIds}
           settings={settings}
           multiSelectedNoteIds={multiSelectedNoteIds}
@@ -403,7 +412,7 @@ export function NoteList({
         data-note-list
         className="group/notelist flex flex-col gap-1 p-1.5 outline-none"
       >
-        {displayItems.map((item) => (
+        {sortedDisplayItems.map((item) => (
           <NoteItemWithMenu
             key={item.id}
             id={item.id}

--- a/src/components/settings/EditorSettingsSection.test.tsx
+++ b/src/components/settings/EditorSettingsSection.test.tsx
@@ -1,0 +1,159 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, it, vi } from "vitest";
+import {
+  EditorToolbarVisibilityControl,
+  EditorWidthResizeControl,
+  TitleBarNoteInfoControls,
+} from "./EditorSettingsSection";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("EditorWidthResizeControl", () => {
+  it("exposes the current state and lets the user disable mouse resizing", () => {
+    const onChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <EditorWidthResizeControl enabled={true} onChange={onChange} />,
+      );
+    });
+
+    const group = container.querySelector(
+      '[role="group"][aria-label="Resize editor with mouse"]',
+    );
+    const [offButton, onButton] = Array.from(
+      container.querySelectorAll("button"),
+    );
+
+    expect(group).not.toBeNull();
+    expect(offButton.textContent).toBe("Off");
+    expect(offButton.getAttribute("aria-pressed")).toBe("false");
+    expect(onButton.textContent).toBe("On");
+    expect(onButton.getAttribute("aria-pressed")).toBe("true");
+
+    act(() => offButton.click());
+    expect(onChange).toHaveBeenCalledWith(false);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});
+
+describe("EditorToolbarVisibilityControl", () => {
+  it("exposes the hidden default and lets the user show the toolbar", () => {
+    const onChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <EditorToolbarVisibilityControl visible={false} onChange={onChange} />,
+      );
+    });
+
+    const group = container.querySelector(
+      '[role="group"][aria-label="Show formatting toolbar"]',
+    );
+    const [offButton, onButton] = Array.from(
+      container.querySelectorAll("button"),
+    );
+
+    expect(group).not.toBeNull();
+    expect(offButton.textContent).toBe("Off");
+    expect(offButton.getAttribute("aria-pressed")).toBe("true");
+    expect(onButton.textContent).toBe("On");
+    expect(onButton.getAttribute("aria-pressed")).toBe("false");
+
+    act(() => onButton.click());
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});
+
+describe("TitleBarNoteInfoControls", () => {
+  it("offers one exclusive title-bar information menu", () => {
+    const onModifiedDateChange = vi.fn();
+    const onFilenameChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <TitleBarNoteInfoControls
+          modifiedDateVisible={true}
+          filenameVisible={false}
+          onModifiedDateChange={onModifiedDateChange}
+          onFilenameChange={onFilenameChange}
+        />,
+      );
+    });
+
+    const select = container.querySelector<HTMLSelectElement>(
+      'select[aria-label="Title bar information"]',
+    );
+    expect(select).not.toBeNull();
+    expect(container.querySelectorAll("select")).toHaveLength(1);
+    expect(Array.from(select?.options ?? []).map((option) => option.text)).toEqual(
+      ["Modification Date", "Filename", "None"],
+    );
+    expect(select?.value).toBe("modifiedDate");
+    expect(container.textContent).not.toContain("On");
+    expect(container.textContent).not.toContain("Off");
+
+    act(() => {
+      if (!select) return;
+      select.value = "filename";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(onFilenameChange).toHaveBeenCalledWith(true);
+    expect(onModifiedDateChange).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("maps None to the single active persisted setting", () => {
+    const onModifiedDateChange = vi.fn();
+    const onFilenameChange = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <TitleBarNoteInfoControls
+          modifiedDateVisible={false}
+          filenameVisible={true}
+          onModifiedDateChange={onModifiedDateChange}
+          onFilenameChange={onFilenameChange}
+        />,
+      );
+    });
+
+    const select = container.querySelector<HTMLSelectElement>(
+      'select[aria-label="Title bar information"]',
+    );
+    expect(select?.value).toBe("filename");
+
+    act(() => {
+      if (!select) return;
+      select.value = "none";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(onFilenameChange).toHaveBeenCalledWith(false);
+    expect(onModifiedDateChange).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/src/components/settings/EditorSettingsSection.tsx
+++ b/src/components/settings/EditorSettingsSection.tsx
@@ -56,6 +56,161 @@ const boldWeightOptions = [
   { value: 800, label: "Extra Bold", excludeForMonospace: false },
 ];
 
+interface EditorWidthResizeControlProps {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}
+
+interface BinarySettingControlProps {
+  label: string;
+  description: string;
+  ariaLabel: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+}
+
+function BinarySettingControl({
+  label,
+  description,
+  ariaLabel,
+  value,
+  onChange,
+}: BinarySettingControlProps) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm text-text font-medium">{label}</div>
+        <p className="text-xs text-text-muted">{description}</p>
+      </div>
+      <div
+        role="group"
+        aria-label={ariaLabel}
+        className="flex gap-1 p-1 rounded-[10px] border border-border shrink-0"
+      >
+        <Button
+          type="button"
+          variant={!value ? "primary" : "ghost"}
+          size="xs"
+          aria-pressed={!value}
+          onClick={() => onChange(false)}
+        >
+          Off
+        </Button>
+        <Button
+          type="button"
+          variant={value ? "primary" : "ghost"}
+          size="xs"
+          aria-pressed={value}
+          onClick={() => onChange(true)}
+        >
+          On
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function EditorWidthResizeControl({
+  enabled,
+  onChange,
+}: EditorWidthResizeControlProps) {
+  return (
+    <BinarySettingControl
+      label="Resize with Mouse"
+      description="Drag the page edges to change its width"
+      ariaLabel="Resize editor with mouse"
+      value={enabled}
+      onChange={onChange}
+    />
+  );
+}
+
+interface EditorToolbarVisibilityControlProps {
+  visible: boolean;
+  onChange: (visible: boolean) => void;
+}
+
+export function EditorToolbarVisibilityControl({
+  visible,
+  onChange,
+}: EditorToolbarVisibilityControlProps) {
+  return (
+    <BinarySettingControl
+      label="Formatting Toolbar"
+      description="Show the fixed toolbar above the document"
+      ariaLabel="Show formatting toolbar"
+      value={visible}
+      onChange={onChange}
+    />
+  );
+}
+
+interface TitleBarNoteInfoControlsProps {
+  modifiedDateVisible: boolean;
+  filenameVisible: boolean;
+  onModifiedDateChange: (visible: boolean) => void;
+  onFilenameChange: (visible: boolean) => void;
+}
+
+type TitleBarNoteInfoMode = "modifiedDate" | "filename" | "none";
+
+export function TitleBarNoteInfoControls({
+  modifiedDateVisible,
+  filenameVisible,
+  onModifiedDateChange,
+  onFilenameChange,
+}: TitleBarNoteInfoControlsProps) {
+  let mode: TitleBarNoteInfoMode = "none";
+  if (filenameVisible) {
+    mode = "filename";
+  } else if (modifiedDateVisible) {
+    mode = "modifiedDate";
+  }
+
+  const handleModeChange = (nextMode: TitleBarNoteInfoMode) => {
+    if (nextMode === "filename") {
+      onFilenameChange(true);
+      return;
+    }
+
+    if (nextMode === "modifiedDate") {
+      onModifiedDateChange(true);
+      return;
+    }
+
+    if (filenameVisible) {
+      onFilenameChange(false);
+    } else if (modifiedDateVisible) {
+      onModifiedDateChange(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <div className="text-sm text-text font-medium">
+          Title Bar Information
+        </div>
+        <p className="text-xs text-text-muted">
+          Choose what appears beside the note icon
+        </p>
+      </div>
+      <Select
+        aria-label="Title bar information"
+        value={mode}
+        onChange={(event) =>
+          handleModeChange(event.target.value as TitleBarNoteInfoMode)
+        }
+        className="w-44"
+      >
+        <option value="modifiedDate">Modification Date</option>
+        <option value="filename">Filename</option>
+        <option value="none">None</option>
+      </Select>
+    </div>
+  );
+}
+
 export function AppearanceSettingsSection() {
   const {
     theme,
@@ -72,6 +227,14 @@ export function AppearanceSettingsSection() {
     setInterfaceZoom,
     customEditorWidthPx,
     setCustomEditorWidthPx,
+    editorWidthResizeEnabled,
+    setEditorWidthResizeEnabled,
+    editorToolbarVisible,
+    setEditorToolbarVisible,
+    titleBarModifiedDateVisible,
+    setTitleBarModifiedDateVisible,
+    titleBarFilenameVisible,
+    setTitleBarFilenameVisible,
     customColorsLight,
     customColorsDark,
     setCustomColor,
@@ -92,14 +255,18 @@ export function AppearanceSettingsSection() {
     setEditorFontSetting(field, clamped);
   };
 
-  // Check if settings differ from defaults
-  const hasCustomFonts =
+  // Check if appearance settings differ from defaults
+  const hasCustomAppearanceSettings =
     editorFontSettings.baseFontFamily !== "system-sans" ||
     editorFontSettings.baseFontSize !== 15 ||
     editorFontSettings.boldWeight !== 600 ||
     editorFontSettings.lineHeight !== 1.6 ||
     textDirection !== "auto" ||
     editorWidth !== "normal" ||
+    !editorWidthResizeEnabled ||
+    editorToolbarVisible ||
+    !titleBarModifiedDateVisible ||
+    titleBarFilenameVisible ||
     Math.round(interfaceZoom * 100) !== 100;
 
   // Filter weight options based on font family
@@ -183,7 +350,7 @@ export function AppearanceSettingsSection() {
       <section>
         <div className="flex items-baseline justify-between mb-3">
           <h2 className="text-xl font-medium">Typography</h2>
-          {hasCustomFonts && (
+          {hasCustomAppearanceSettings && (
             <Button onClick={resetEditorFontSettings} variant="ghost" size="sm">
               Reset to defaults
             </Button>
@@ -323,6 +490,23 @@ export function AppearanceSettingsSection() {
               </div>
             </div>
           )}
+
+          <EditorWidthResizeControl
+            enabled={editorWidthResizeEnabled}
+            onChange={setEditorWidthResizeEnabled}
+          />
+
+          <EditorToolbarVisibilityControl
+            visible={editorToolbarVisible}
+            onChange={setEditorToolbarVisible}
+          />
+
+          <TitleBarNoteInfoControls
+            modifiedDateVisible={titleBarModifiedDateVisible}
+            filenameVisible={titleBarFilenameVisible}
+            onModifiedDateChange={setTitleBarModifiedDateVisible}
+            onFilenameChange={setTitleBarFilenameVisible}
+          />
 
           {/* Interface Zoom */}
           <div className="flex items-center justify-between">

--- a/src/context/ThemeContext.test.tsx
+++ b/src/context/ThemeContext.test.tsx
@@ -1,0 +1,117 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Settings } from "../types/note";
+import { ThemeProvider, useTheme } from "./ThemeContext";
+
+const serviceMocks = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+const toastError = vi.hoisted(() => vi.fn());
+
+vi.mock("../services/notes", () => serviceMocks);
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async () => undefined),
+}));
+vi.mock("sonner", () => ({
+  toast: { error: toastError },
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const persistedSettings: Settings = {
+  theme: { mode: "system" },
+  editorWidthResizeEnabled: false,
+  editorToolbarVisible: true,
+  titleBarModifiedDateVisible: false,
+  titleBarFilenameVisible: true,
+};
+
+describe("ThemeProvider appearance reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceMocks.getSettings.mockResolvedValue({ ...persistedSettings });
+    serviceMocks.updateSettings.mockResolvedValue(undefined);
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: false,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+  });
+
+  it("keeps hook order stable and restores persisted settings after a failed reset", async () => {
+    let latestTheme: ReturnType<typeof useTheme> | undefined;
+    const currentTheme = () => {
+      if (!latestTheme) throw new Error("Theme context was not rendered");
+      return latestTheme;
+    };
+    function Probe() {
+      latestTheme = useTheme();
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      );
+    });
+
+    expect(currentTheme().editorWidthResizeEnabled).toBe(false);
+    expect(currentTheme().editorToolbarVisible).toBe(true);
+    expect(currentTheme().titleBarFilenameVisible).toBe(true);
+
+    serviceMocks.getSettings.mockClear();
+    serviceMocks.updateSettings.mockReset();
+    serviceMocks.updateSettings.mockRejectedValueOnce(
+      new Error("disk unavailable"),
+    );
+    toastError.mockClear();
+
+    await act(async () => {
+      await (
+        currentTheme().resetEditorFontSettings as unknown as () => Promise<void>
+      )();
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Appearance settings could not be reset",
+    );
+    expect(serviceMocks.getSettings).toHaveBeenCalledTimes(2);
+    expect(currentTheme().editorWidthResizeEnabled).toBe(false);
+    expect(currentTheme().editorToolbarVisible).toBe(true);
+    expect(currentTheme().titleBarFilenameVisible).toBe(true);
+
+    serviceMocks.getSettings.mockClear();
+    serviceMocks.updateSettings.mockReset();
+    serviceMocks.updateSettings.mockRejectedValueOnce(
+      new Error("disk still unavailable"),
+    );
+    toastError.mockClear();
+
+    await act(async () => {
+      await (
+        currentTheme().setEditorToolbarVisible as unknown as (
+          visible: boolean,
+        ) => Promise<void>
+      )(false);
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      "Appearance setting could not be saved",
+    );
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useCallback,
   useRef,
+  useMemo,
   type ReactNode,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
@@ -29,6 +30,7 @@ import type {
   ThemeColorKey,
   Settings,
 } from "../types/note";
+import { toast } from "sonner";
 
 type ThemeMode = "light" | "dark" | "system";
 
@@ -476,9 +478,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         customColorsDark: undefined,
       });
     } catch (error) {
-      console.error("Failed to reset editor settings:", error);
+      console.error("Failed to reset appearance settings:", error);
+      toast.error("Appearance settings could not be reset");
+      await loadSettingsFromBackend();
     }
-  }, [applyTitleBarNoteInfoVisibility]);
+  }, [applyTitleBarNoteInfoVisibility, loadSettingsFromBackend]);
 
   // Save and set text direction
   const setTextDirection = useCallback(async (dir: TextDirection) => {
@@ -719,45 +723,82 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     return null;
   }
 
+  const contextValue = useMemo<ThemeContextType>(
+    () => ({
+      theme,
+      resolvedTheme,
+      setTheme,
+      cycleTheme,
+      editorFontSettings,
+      setEditorFontSetting,
+      resetEditorFontSettings,
+      reloadSettings,
+      textDirection,
+      setTextDirection,
+      editorWidth,
+      setEditorWidth,
+      interfaceZoom,
+      setInterfaceZoom,
+      customEditorWidthPx,
+      setCustomEditorWidthPx,
+      editorWidthResizeEnabled,
+      setEditorWidthResizeEnabled,
+      editorToolbarVisible,
+      setEditorToolbarVisible,
+      titleBarModifiedDateVisible:
+        titleBarNoteInfoVisibility.modifiedDateVisible,
+      setTitleBarModifiedDateVisible,
+      titleBarFilenameVisible: titleBarNoteInfoVisibility.filenameVisible,
+      setTitleBarFilenameVisible,
+      setEditorMaxWidthLive,
+      sidebarWidthPx,
+      setSidebarWidthPx,
+      setSidebarWidthLive,
+      customColorsLight,
+      customColorsDark,
+      setCustomColor,
+      resetCustomColor,
+      resetAllCustomColors,
+    }),
+    [
+      theme,
+      resolvedTheme,
+      setTheme,
+      cycleTheme,
+      editorFontSettings,
+      setEditorFontSetting,
+      resetEditorFontSettings,
+      reloadSettings,
+      textDirection,
+      setTextDirection,
+      editorWidth,
+      setEditorWidth,
+      interfaceZoom,
+      setInterfaceZoom,
+      customEditorWidthPx,
+      setCustomEditorWidthPx,
+      editorWidthResizeEnabled,
+      setEditorWidthResizeEnabled,
+      editorToolbarVisible,
+      setEditorToolbarVisible,
+      titleBarNoteInfoVisibility.modifiedDateVisible,
+      setTitleBarModifiedDateVisible,
+      titleBarNoteInfoVisibility.filenameVisible,
+      setTitleBarFilenameVisible,
+      setEditorMaxWidthLive,
+      sidebarWidthPx,
+      setSidebarWidthPx,
+      setSidebarWidthLive,
+      customColorsLight,
+      customColorsDark,
+      setCustomColor,
+      resetCustomColor,
+      resetAllCustomColors,
+    ],
+  );
+
   return (
-    <ThemeContext.Provider
-      value={{
-        theme,
-        resolvedTheme,
-        setTheme,
-        cycleTheme,
-        editorFontSettings,
-        setEditorFontSetting,
-        resetEditorFontSettings,
-        reloadSettings,
-        textDirection,
-        setTextDirection,
-        editorWidth,
-        setEditorWidth,
-        interfaceZoom,
-        setInterfaceZoom,
-        customEditorWidthPx,
-        setCustomEditorWidthPx,
-        editorWidthResizeEnabled,
-        setEditorWidthResizeEnabled,
-        editorToolbarVisible,
-        setEditorToolbarVisible,
-        titleBarModifiedDateVisible:
-          titleBarNoteInfoVisibility.modifiedDateVisible,
-        setTitleBarModifiedDateVisible,
-        titleBarFilenameVisible: titleBarNoteInfoVisibility.filenameVisible,
-        setTitleBarFilenameVisible,
-        setEditorMaxWidthLive,
-        sidebarWidthPx,
-        setSidebarWidthPx,
-        setSidebarWidthLive,
-        customColorsLight,
-        customColorsDark,
-        setCustomColor,
-        resetCustomColor,
-        resetAllCustomColors,
-      }}
-    >
+    <ThemeContext.Provider value={contextValue}>
       {children}
     </ThemeContext.Provider>
   );

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -4,11 +4,21 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   type ReactNode,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getSettings, updateSettings } from "../services/notes";
 import { SIDEBAR_MIN_PX, SIDEBAR_MAX_PX } from "../lib/sidebar";
+import { resolveEditorWidthResizeEnabled } from "../lib/editorWidthResize";
+import { resolveEditorToolbarVisible } from "../lib/editorToolbar";
+import {
+  DEFAULT_TITLE_BAR_NOTE_INFO_VISIBILITY,
+  resolveTitleBarNoteInfoVisibility,
+  updateTitleBarNoteInfoVisibility,
+  type TitleBarNoteInfoKind,
+  type TitleBarNoteInfoVisibility,
+} from "../lib/titleBarNoteInfo";
 import type {
   ThemeSettings,
   EditorFontSettings,
@@ -17,6 +27,7 @@ import type {
   EditorWidth,
   CustomColors,
   ThemeColorKey,
+  Settings,
 } from "../types/note";
 
 type ThemeMode = "light" | "dark" | "system";
@@ -112,6 +123,14 @@ interface ThemeContextType {
   setInterfaceZoom: (zoomOrUpdater: number | ((prev: number) => number)) => void;
   customEditorWidthPx: number;
   setCustomEditorWidthPx: (px: number) => void;
+  editorWidthResizeEnabled: boolean;
+  setEditorWidthResizeEnabled: (enabled: boolean) => void;
+  editorToolbarVisible: boolean;
+  setEditorToolbarVisible: (visible: boolean) => void;
+  titleBarModifiedDateVisible: boolean;
+  setTitleBarModifiedDateVisible: (visible: boolean) => void;
+  titleBarFilenameVisible: boolean;
+  setTitleBarFilenameVisible: (visible: boolean) => void;
   setEditorMaxWidthLive: (value: string) => void;
   sidebarWidthPx: number | null;
   setSidebarWidthPx: (px: number | null) => void;
@@ -191,10 +210,32 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
   const [customEditorWidthPx, setCustomEditorWidthPxState] = useState<number>(
     DEFAULT_CUSTOM_WIDTH_PX
   );
+  const [editorWidthResizeEnabled, setEditorWidthResizeEnabledState] =
+    useState(true);
+  const [editorToolbarVisible, setEditorToolbarVisibleState] = useState(false);
+  const [titleBarNoteInfoVisibility, setTitleBarNoteInfoVisibility] =
+    useState<TitleBarNoteInfoVisibility>(
+      DEFAULT_TITLE_BAR_NOTE_INFO_VISIBILITY,
+    );
   const [sidebarWidthPx, setSidebarWidthPxState] = useState<number | null>(null);
   const [customColorsLight, setCustomColorsLightState] = useState<CustomColors>({});
   const [customColorsDark, setCustomColorsDarkState] = useState<CustomColors>({});
   const [isInitialized, setIsInitialized] = useState(false);
+  const titleBarNoteInfoVisibilityRef = useRef<TitleBarNoteInfoVisibility>(
+    DEFAULT_TITLE_BAR_NOTE_INFO_VISIBILITY,
+  );
+  const applyTitleBarNoteInfoVisibility = useCallback(
+    (visibility: TitleBarNoteInfoVisibility) => {
+      titleBarNoteInfoVisibilityRef.current = visibility;
+      setTitleBarNoteInfoVisibility(visibility);
+    },
+    [],
+  );
+
+  const updateSettingsPatch = useCallback(async (patch: Partial<Settings>) => {
+    const settings = await getSettings();
+    await updateSettings({ ...settings, ...patch });
+  }, []);
 
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">(() => {
     return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -247,6 +288,18 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       ) {
         setCustomEditorWidthPxState(settings.customEditorWidthPx);
       }
+      setEditorWidthResizeEnabledState(
+        resolveEditorWidthResizeEnabled(settings.editorWidthResizeEnabled),
+      );
+      setEditorToolbarVisibleState(
+        resolveEditorToolbarVisible(settings.editorToolbarVisible),
+      );
+      applyTitleBarNoteInfoVisibility(
+        resolveTitleBarNoteInfoVisibility(
+          settings.titleBarModifiedDateVisible,
+          settings.titleBarFilenameVisible,
+        ),
+      );
       if (
         typeof settings.sidebarWidthPx === "number" &&
         settings.sidebarWidthPx >= SIDEBAR_MIN_PX &&
@@ -263,7 +316,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     } catch {
       // If settings can't be loaded, use defaults
     }
-  }, []);
+  }, [applyTitleBarNoteInfoVisibility]);
 
   // Reload settings from backend (exposed to context consumers)
   const reloadSettings = useCallback(async () => {
@@ -399,6 +452,9 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     setEditorWidthState("normal");
     setInterfaceZoomState(1.0);
     setCustomEditorWidthPxState(DEFAULT_CUSTOM_WIDTH_PX);
+    setEditorWidthResizeEnabledState(true);
+    setEditorToolbarVisibleState(false);
+    applyTitleBarNoteInfoVisibility(DEFAULT_TITLE_BAR_NOTE_INFO_VISIBILITY);
     setSidebarWidthPxState(null);
     setCustomColorsLightState({});
     setCustomColorsDarkState({});
@@ -411,6 +467,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         editorWidth: "normal",
         interfaceZoom: 1.0,
         customEditorWidthPx: undefined,
+        editorWidthResizeEnabled: undefined,
+        editorToolbarVisible: undefined,
+        titleBarModifiedDateVisible: undefined,
+        titleBarFilenameVisible: undefined,
         sidebarWidthPx: undefined,
         customColorsLight: undefined,
         customColorsDark: undefined,
@@ -418,7 +478,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     } catch (error) {
       console.error("Failed to reset editor settings:", error);
     }
-  }, []);
+  }, [applyTitleBarNoteInfoVisibility]);
 
   // Save and set text direction
   const setTextDirection = useCallback(async (dir: TextDirection) => {
@@ -483,6 +543,58 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       console.error("Failed to save custom editor width:", error);
     }
   }, []);
+
+  const setEditorWidthResizeEnabled = useCallback(
+    async (enabled: boolean) => {
+      setEditorWidthResizeEnabledState(enabled);
+      try {
+        await updateSettingsPatch({ editorWidthResizeEnabled: enabled });
+      } catch (error) {
+        console.error("Failed to save editor width resize setting:", error);
+      }
+    },
+    [updateSettingsPatch],
+  );
+
+  const setEditorToolbarVisible = useCallback(
+    async (visible: boolean) => {
+      setEditorToolbarVisibleState(visible);
+      try {
+        await updateSettingsPatch({ editorToolbarVisible: visible });
+      } catch (error) {
+        console.error("Failed to save editor toolbar setting:", error);
+      }
+    },
+    [updateSettingsPatch],
+  );
+
+  const updateTitleBarNoteInfo = useCallback(
+    (kind: TitleBarNoteInfoKind, visible: boolean) => {
+      const next = updateTitleBarNoteInfoVisibility(
+        titleBarNoteInfoVisibilityRef.current,
+        kind,
+        visible,
+      );
+      applyTitleBarNoteInfoVisibility(next);
+      void updateSettingsPatch({
+        titleBarModifiedDateVisible: next.modifiedDateVisible,
+        titleBarFilenameVisible: next.filenameVisible,
+      }).catch((error) => {
+        console.error("Failed to save title bar information setting:", error);
+      });
+    },
+    [applyTitleBarNoteInfoVisibility, updateSettingsPatch],
+  );
+
+  const setTitleBarModifiedDateVisible = useCallback(
+    (visible: boolean) => updateTitleBarNoteInfo("modifiedDate", visible),
+    [updateTitleBarNoteInfo],
+  );
+
+  const setTitleBarFilenameVisible = useCallback(
+    (visible: boolean) => updateTitleBarNoteInfo("filename", visible),
+    [updateTitleBarNoteInfo],
+  );
 
   /**
    * Persists the clamped sidebar width to settings.
@@ -626,6 +738,15 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         setInterfaceZoom,
         customEditorWidthPx,
         setCustomEditorWidthPx,
+        editorWidthResizeEnabled,
+        setEditorWidthResizeEnabled,
+        editorToolbarVisible,
+        setEditorToolbarVisible,
+        titleBarModifiedDateVisible:
+          titleBarNoteInfoVisibility.modifiedDateVisible,
+        setTitleBarModifiedDateVisible,
+        titleBarFilenameVisible: titleBarNoteInfoVisibility.filenameVisible,
+        setTitleBarFilenameVisible,
         setEditorMaxWidthLive,
         sidebarWidthPx,
         setSidebarWidthPx,

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -20,6 +20,7 @@ import {
   type TitleBarNoteInfoKind,
   type TitleBarNoteInfoVisibility,
 } from "../lib/titleBarNoteInfo";
+import { createSettingsPatchQueue } from "../lib/settingsUpdateQueue";
 import type {
   ThemeSettings,
   EditorFontSettings,
@@ -28,7 +29,6 @@ import type {
   EditorWidth,
   CustomColors,
   ThemeColorKey,
-  Settings,
 } from "../types/note";
 import { toast } from "sonner";
 
@@ -234,10 +234,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     [],
   );
 
-  const updateSettingsPatch = useCallback(async (patch: Partial<Settings>) => {
-    const settings = await getSettings();
-    await updateSettings({ ...settings, ...patch });
-  }, []);
+  const updateSettingsPatch = useMemo(
+    () => createSettingsPatchQueue(getSettings, updateSettings),
+    [],
+  );
 
   const [systemTheme, setSystemTheme] = useState<"light" | "dark">(() => {
     return window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -461,9 +461,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     setCustomColorsLightState({});
     setCustomColorsDarkState({});
     try {
-      const settings = await getSettings();
-      await updateSettings({
-        ...settings,
+      await updateSettingsPatch({
         editorFont: defaultEditorFontSettings,
         textDirection: "auto",
         editorWidth: "normal",
@@ -482,7 +480,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       toast.error("Appearance settings could not be reset");
       await loadSettingsFromBackend();
     }
-  }, [applyTitleBarNoteInfoVisibility, loadSettingsFromBackend]);
+  }, [
+    applyTitleBarNoteInfoVisibility,
+    loadSettingsFromBackend,
+    updateSettingsPatch,
+  ]);
 
   // Save and set text direction
   const setTextDirection = useCallback(async (dir: TextDirection) => {
@@ -555,6 +557,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         await updateSettingsPatch({ editorWidthResizeEnabled: enabled });
       } catch (error) {
         console.error("Failed to save editor width resize setting:", error);
+        toast.error("Appearance setting could not be saved");
       }
     },
     [updateSettingsPatch],
@@ -567,6 +570,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         await updateSettingsPatch({ editorToolbarVisible: visible });
       } catch (error) {
         console.error("Failed to save editor toolbar setting:", error);
+        toast.error("Appearance setting could not be saved");
       }
     },
     [updateSettingsPatch],
@@ -585,6 +589,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         titleBarFilenameVisible: next.filenameVisible,
       }).catch((error) => {
         console.error("Failed to save title bar information setting:", error);
+        toast.error("Appearance setting could not be saved");
       });
     },
     [applyTitleBarNoteInfoVisibility, updateSettingsPatch],
@@ -718,11 +723,6 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     document.documentElement.style.setProperty("--sidebar-width", `${px}px`);
   }, []);
 
-  // Don't render until initialized to prevent flash
-  if (!isInitialized) {
-    return null;
-  }
-
   const contextValue = useMemo<ThemeContextType>(
     () => ({
       theme,
@@ -796,6 +796,12 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       resetAllCustomColors,
     ],
   );
+
+  // Don't render until initialized to prevent flash. Keep this after every
+  // hook so the provider calls hooks in the same order on every render.
+  if (!isInitialized) {
+    return null;
+  }
 
   return (
     <ThemeContext.Provider value={contextValue}>

--- a/src/lib/editorToolbar.test.ts
+++ b/src/lib/editorToolbar.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveEditorToolbarVisible } from "./editorToolbar";
+
+describe("resolveEditorToolbarVisible", () => {
+  it("hides the toolbar when an existing settings file has no preference", () => {
+    expect(resolveEditorToolbarVisible(undefined)).toBe(false);
+  });
+
+  it("honors an explicit visibility preference", () => {
+    expect(resolveEditorToolbarVisible(false)).toBe(false);
+    expect(resolveEditorToolbarVisible(true)).toBe(true);
+  });
+});

--- a/src/lib/editorToolbar.ts
+++ b/src/lib/editorToolbar.ts
@@ -1,0 +1,9 @@
+/**
+ * Existing settings files do not contain this preference. Keep the fixed
+ * formatting toolbar hidden until the user explicitly enables it.
+ */
+export function resolveEditorToolbarVisible(
+  value: boolean | undefined,
+): boolean {
+  return value === true;
+}

--- a/src/lib/editorWidthResize.test.ts
+++ b/src/lib/editorWidthResize.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { resolveEditorWidthResizeEnabled } from "./editorWidthResize";
+
+describe("resolveEditorWidthResizeEnabled", () => {
+  it("keeps mouse width resizing enabled for existing settings", () => {
+    expect(resolveEditorWidthResizeEnabled(undefined)).toBe(true);
+  });
+
+  it("honors an explicit disabled setting", () => {
+    expect(resolveEditorWidthResizeEnabled(false)).toBe(false);
+    expect(resolveEditorWidthResizeEnabled(true)).toBe(true);
+  });
+});

--- a/src/lib/editorWidthResize.ts
+++ b/src/lib/editorWidthResize.ts
@@ -1,0 +1,9 @@
+/**
+ * Existing settings files do not contain this preference, so mouse resizing
+ * remains enabled unless the user explicitly turns it off.
+ */
+export function resolveEditorWidthResizeEnabled(
+  value: boolean | undefined,
+): boolean {
+  return value !== false;
+}

--- a/src/lib/folderTree.test.ts
+++ b/src/lib/folderTree.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { NoteMetadata } from "../types/note";
+import {
+  buildFolderTree,
+  getVisibleItemsForFolderSection,
+  sortNotesByModified,
+} from "./folderTree";
+
+function note(id: string, modified: number): NoteMetadata {
+  return {
+    id,
+    title: id,
+    preview: "",
+    modified,
+  };
+}
+
+describe("sortNotesByModified", () => {
+  const notes = [note("middle", 20), note("oldest", 10), note("newest", 30)];
+
+  it("sorts newest first without mutating the source list", () => {
+    const result = sortNotesByModified(notes, "newest");
+
+    expect(result.map((item) => item.id)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+    expect(notes.map((item) => item.id)).toEqual([
+      "middle",
+      "oldest",
+      "newest",
+    ]);
+  });
+
+  it("sorts oldest first with a deterministic filename tie-break", () => {
+    const result = sortNotesByModified(
+      [note("z-last", 10), note("a-first", 10), note("newest", 30)],
+      "oldest",
+    );
+
+    expect(result.map((item) => item.id)).toEqual([
+      "a-first",
+      "z-last",
+      "newest",
+    ]);
+  });
+});
+
+describe("buildFolderTree note order", () => {
+  it("applies oldest-first ordering inside folders while keeping pinned notes first", () => {
+    const tree = buildFolderTree(
+      [
+        note("docs/newest", 30),
+        note("docs/pinned", 20),
+        note("docs/oldest", 10),
+      ],
+      new Set(["docs/pinned"]),
+      ["docs"],
+      "oldest",
+    );
+
+    expect(tree.folders[0]?.notes.map((item) => item.id)).toEqual([
+      "docs/pinned",
+      "docs/oldest",
+      "docs/newest",
+    ]);
+  });
+});
+
+describe("getVisibleItemsForFolderSection", () => {
+  it("hides every folder item while keeping root notes keyboard-accessible", () => {
+    const pinnedIds = new Set(["pinned"]);
+    const tree = buildFolderTree(
+      [
+        note("pinned", 30),
+        note("docs/inside", 20),
+        note("recent", 10),
+      ],
+      pinnedIds,
+      ["docs"],
+    );
+
+    expect(
+      getVisibleItemsForFolderSection(tree, pinnedIds, new Set(), false),
+    ).toEqual([
+      { type: "note", id: "pinned" },
+      { type: "folder", path: "docs" },
+      { type: "note", id: "docs/inside" },
+      { type: "note", id: "recent" },
+    ]);
+    expect(
+      getVisibleItemsForFolderSection(tree, pinnedIds, new Set(), true),
+    ).toEqual([
+      { type: "note", id: "pinned" },
+      { type: "note", id: "recent" },
+    ]);
+  });
+});

--- a/src/lib/folderTree.ts
+++ b/src/lib/folderTree.ts
@@ -1,14 +1,40 @@
-import type { NoteMetadata, FolderNode } from "../types/note";
+import type {
+  NoteMetadata,
+  FolderNode,
+  NoteSortOrder,
+} from "../types/note";
 
 export interface FolderTreeData {
   rootNotes: NoteMetadata[];
   folders: FolderNode[];
 }
 
+function compareNotesByModified(
+  first: Pick<NoteMetadata, "id" | "modified">,
+  second: Pick<NoteMetadata, "id" | "modified">,
+  sortOrder: NoteSortOrder,
+): number {
+  const modifiedDifference =
+    sortOrder === "oldest"
+      ? first.modified - second.modified
+      : second.modified - first.modified;
+
+  return modifiedDifference || first.id.localeCompare(second.id);
+}
+
+export function sortNotesByModified<
+  T extends Pick<NoteMetadata, "id" | "modified">,
+>(notes: readonly T[], sortOrder: NoteSortOrder): T[] {
+  return [...notes].sort((first, second) =>
+    compareNotesByModified(first, second, sortOrder),
+  );
+}
+
 export function buildFolderTree(
   notes: NoteMetadata[],
   pinnedIds: Set<string>,
   knownFolders?: string[],
+  sortOrder: NoteSortOrder = "newest",
 ): FolderTreeData {
   const rootNotes: NoteMetadata[] = [];
   const folderMap = new Map<string, FolderNode>();
@@ -51,14 +77,16 @@ export function buildFolderTree(
     }
   }
 
+  const compareFolderNotes = (first: NoteMetadata, second: NoteMetadata) => {
+    const firstPinned = pinnedIds.has(first.id);
+    const secondPinned = pinnedIds.has(second.id);
+    if (firstPinned !== secondPinned) return firstPinned ? -1 : 1;
+    return compareNotesByModified(first, second, sortOrder);
+  };
+
   function sortNode(node: FolderNode) {
     node.children.sort((a, b) => a.name.localeCompare(b.name));
-    node.notes.sort((a, b) => {
-      const ap = pinnedIds.has(a.id);
-      const bp = pinnedIds.has(b.id);
-      if (ap !== bp) return ap ? -1 : 1;
-      return b.modified - a.modified;
-    });
+    node.notes.sort(compareFolderNotes);
     node.children.forEach(sortNode);
   }
 
@@ -68,13 +96,8 @@ export function buildFolderTree(
   topLevelFolders.sort((a, b) => a.name.localeCompare(b.name));
   topLevelFolders.forEach(sortNode);
 
-  // Sort root notes: pinned first, then by modified desc
-  rootNotes.sort((a, b) => {
-    const ap = pinnedIds.has(a.id);
-    const bp = pinnedIds.has(b.id);
-    if (ap !== bp) return ap ? -1 : 1;
-    return b.modified - a.modified;
-  });
+  // Keep pinned notes first, then apply the selected date order.
+  rootNotes.sort(compareFolderNotes);
 
   return { rootNotes, folders: topLevelFolders };
 }
@@ -122,6 +145,20 @@ export function getVisibleItems(
   }
 
   return items;
+}
+
+/** Hide the folder branch from keyboard navigation when its section is closed. */
+export function getVisibleItemsForFolderSection(
+  tree: FolderTreeData,
+  pinnedIds: Set<string>,
+  collapsedFolders: Set<string>,
+  foldersSectionCollapsed: boolean,
+): TreeItem[] {
+  return getVisibleItems(
+    foldersSectionCollapsed ? { ...tree, folders: [] } : tree,
+    pinnedIds,
+    collapsedFolders,
+  );
 }
 
 export function countNotesInFolder(folder: FolderNode): number {

--- a/src/lib/settingsUpdateQueue.test.ts
+++ b/src/lib/settingsUpdateQueue.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Settings } from "../types/note";
+import { createSettingsPatchQueue } from "./settingsUpdateQueue";
+
+function settings(): Settings {
+  return { theme: { mode: "system" } };
+}
+
+describe("createSettingsPatchQueue", () => {
+  it("reloads settings after each queued save so concurrent patches are retained", async () => {
+    let stored = settings();
+    let releaseFirstSave: (() => void) | undefined;
+    const firstSaveBlocked = new Promise<void>((resolve) => {
+      releaseFirstSave = resolve;
+    });
+    const loadSettings = vi.fn(async () => ({ ...stored }));
+    const saveSettings = vi.fn(async (next: Settings) => {
+      if (saveSettings.mock.calls.length === 1) {
+        await firstSaveBlocked;
+      }
+      stored = next;
+    });
+    const patchSettings = createSettingsPatchQueue(loadSettings, saveSettings);
+
+    const resizeUpdate = patchSettings({ editorWidthResizeEnabled: false });
+    const toolbarUpdate = patchSettings({ editorToolbarVisible: true });
+    await Promise.resolve();
+
+    expect(loadSettings).toHaveBeenCalledTimes(1);
+    releaseFirstSave?.();
+    await Promise.all([resizeUpdate, toolbarUpdate]);
+
+    expect(loadSettings).toHaveBeenCalledTimes(2);
+    expect(stored.editorWidthResizeEnabled).toBe(false);
+    expect(stored.editorToolbarVisible).toBe(true);
+  });
+
+  it("continues processing after a failed save", async () => {
+    let stored = settings();
+    const loadSettings = vi.fn(async () => ({ ...stored }));
+    const saveSettings = vi
+      .fn<(next: Settings) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("disk unavailable"))
+      .mockImplementationOnce(async (next) => {
+        stored = next;
+      });
+    const patchSettings = createSettingsPatchQueue(loadSettings, saveSettings);
+
+    const failedUpdate = patchSettings({ editorToolbarVisible: true });
+    const nextUpdate = patchSettings({ editorWidthResizeEnabled: false });
+
+    await expect(failedUpdate).rejects.toThrow("disk unavailable");
+    await expect(nextUpdate).resolves.toBeUndefined();
+    expect(stored.editorWidthResizeEnabled).toBe(false);
+  });
+});

--- a/src/lib/settingsUpdateQueue.ts
+++ b/src/lib/settingsUpdateQueue.ts
@@ -1,0 +1,21 @@
+import type { Settings } from "../types/note";
+
+type LoadSettings = () => Promise<Settings>;
+type SaveSettings = (settings: Settings) => Promise<void>;
+
+export function createSettingsPatchQueue(
+  loadSettings: LoadSettings,
+  saveSettings: SaveSettings,
+) {
+  let queue: Promise<void> = Promise.resolve();
+
+  return (patch: Partial<Settings>): Promise<void> => {
+    const update = queue.then(async () => {
+      const settings = await loadSettings();
+      await saveSettings({ ...settings, ...patch });
+    });
+
+    queue = update.catch(() => undefined);
+    return update;
+  };
+}

--- a/src/lib/titleBarNoteInfo.test.ts
+++ b/src/lib/titleBarNoteInfo.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFilenameFromPath,
+  getTitleBarNoteInfoText,
+  resolveTitleBarNoteInfoVisibility,
+  updateTitleBarNoteInfoVisibility,
+} from "./titleBarNoteInfo";
+
+describe("resolveTitleBarNoteInfoVisibility", () => {
+  it("preserves the existing modification-date behavior by default", () => {
+    expect(resolveTitleBarNoteInfoVisibility(undefined, undefined)).toEqual({
+      modifiedDateVisible: true,
+      filenameVisible: false,
+    });
+  });
+
+  it("allows both title-bar values to be hidden", () => {
+    expect(resolveTitleBarNoteInfoVisibility(false, false)).toEqual({
+      modifiedDateVisible: false,
+      filenameVisible: false,
+    });
+  });
+
+  it("gives filename priority if an old settings file enables both", () => {
+    expect(resolveTitleBarNoteInfoVisibility(true, true)).toEqual({
+      modifiedDateVisible: false,
+      filenameVisible: true,
+    });
+  });
+});
+
+describe("updateTitleBarNoteInfoVisibility", () => {
+  it("replaces the modification date when filename is enabled", () => {
+    expect(
+      updateTitleBarNoteInfoVisibility(
+        { modifiedDateVisible: true, filenameVisible: false },
+        "filename",
+        true,
+      ),
+    ).toEqual({ modifiedDateVisible: false, filenameVisible: true });
+  });
+
+  it("replaces filename when the modification date is enabled", () => {
+    expect(
+      updateTitleBarNoteInfoVisibility(
+        { modifiedDateVisible: false, filenameVisible: true },
+        "modifiedDate",
+        true,
+      ),
+    ).toEqual({ modifiedDateVisible: true, filenameVisible: false });
+  });
+
+  it("can leave both values hidden", () => {
+    expect(
+      updateTitleBarNoteInfoVisibility(
+        { modifiedDateVisible: true, filenameVisible: false },
+        "modifiedDate",
+        false,
+      ),
+    ).toEqual({ modifiedDateVisible: false, filenameVisible: false });
+  });
+});
+
+describe("getFilenameFromPath", () => {
+  it("returns the Markdown filename without its extension from macOS and Windows paths", () => {
+    expect(getFilenameFromPath("/Users/marie/Notes/Project plan.md")).toBe(
+      "Project plan",
+    );
+    expect(getFilenameFromPath("C:\\Users\\marie\\Notes\\Project plan.md")).toBe(
+      "Project plan",
+    );
+  });
+
+  it("only removes a final Markdown extension", () => {
+    expect(getFilenameFromPath("/Users/marie/Notes/Project plan.md.backup")).toBe(
+      "Project plan.md.backup",
+    );
+  });
+});
+
+describe("getTitleBarNoteInfoText", () => {
+  const note = {
+    path: "/Users/marie/Notes/Project plan.md",
+    modified: 42,
+  };
+  const formatModifiedDate = (timestamp: number) => `modified:${timestamp}`;
+
+  it("returns the formatted modification date", () => {
+    expect(
+      getTitleBarNoteInfoText(
+        { modifiedDateVisible: true, filenameVisible: false },
+        note,
+        formatModifiedDate,
+      ),
+    ).toBe("modified:42");
+  });
+
+  it("returns filename instead of the modification date", () => {
+    expect(
+      getTitleBarNoteInfoText(
+        { modifiedDateVisible: false, filenameVisible: true },
+        note,
+        formatModifiedDate,
+      ),
+    ).toBe("Project plan");
+  });
+
+  it("returns null when both values are hidden", () => {
+    expect(
+      getTitleBarNoteInfoText(
+        { modifiedDateVisible: false, filenameVisible: false },
+        note,
+        formatModifiedDate,
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/lib/titleBarNoteInfo.test.ts
+++ b/src/lib/titleBarNoteInfo.test.ts
@@ -59,6 +59,16 @@ describe("updateTitleBarNoteInfoVisibility", () => {
       ),
     ).toEqual({ modifiedDateVisible: false, filenameVisible: false });
   });
+
+  it("does not restore the modification date when filename is hidden", () => {
+    expect(
+      updateTitleBarNoteInfoVisibility(
+        { modifiedDateVisible: false, filenameVisible: true },
+        "filename",
+        false,
+      ),
+    ).toEqual({ modifiedDateVisible: false, filenameVisible: false });
+  });
 });
 
 describe("getFilenameFromPath", () => {

--- a/src/lib/titleBarNoteInfo.ts
+++ b/src/lib/titleBarNoteInfo.ts
@@ -1,0 +1,70 @@
+export interface TitleBarNoteInfoVisibility {
+  modifiedDateVisible: boolean;
+  filenameVisible: boolean;
+}
+
+export type TitleBarNoteInfoKind = "modifiedDate" | "filename";
+
+export const DEFAULT_TITLE_BAR_NOTE_INFO_VISIBILITY: TitleBarNoteInfoVisibility = {
+  modifiedDateVisible: true,
+  filenameVisible: false,
+};
+
+export function resolveTitleBarNoteInfoVisibility(
+  modifiedDateVisible: boolean | undefined,
+  filenameVisible: boolean | undefined,
+): TitleBarNoteInfoVisibility {
+  if (filenameVisible === true) {
+    return { modifiedDateVisible: false, filenameVisible: true };
+  }
+
+  return {
+    modifiedDateVisible: modifiedDateVisible !== false,
+    filenameVisible: false,
+  };
+}
+
+export function updateTitleBarNoteInfoVisibility(
+  current: TitleBarNoteInfoVisibility,
+  kind: TitleBarNoteInfoKind,
+  visible: boolean,
+): TitleBarNoteInfoVisibility {
+  if (kind === "filename") {
+    return {
+      modifiedDateVisible: visible ? false : current.modifiedDateVisible,
+      filenameVisible: visible,
+    };
+  }
+
+  return {
+    modifiedDateVisible: visible,
+    filenameVisible: visible ? false : current.filenameVisible,
+  };
+}
+
+export function getFilenameFromPath(path: string): string {
+  const parts = path.split(/[/\\]/).filter(Boolean);
+  const filename = parts[parts.length - 1] ?? "";
+  return filename.replace(/\.md$/, "");
+}
+
+interface TitleBarNote {
+  path: string;
+  modified: number;
+}
+
+export function getTitleBarNoteInfoText(
+  visibility: TitleBarNoteInfoVisibility,
+  note: TitleBarNote,
+  formatModifiedDate: (timestamp: number) => string,
+): string | null {
+  if (visibility.filenameVisible) {
+    return getFilenameFromPath(note.path);
+  }
+
+  if (visibility.modifiedDateVisible) {
+    return formatModifiedDate(note.modified);
+  }
+
+  return null;
+}

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -55,6 +55,10 @@ export interface Settings {
   textDirection?: TextDirection;
   editorWidth?: EditorWidth;
   customEditorWidthPx?: number;
+  editorWidthResizeEnabled?: boolean;
+  editorToolbarVisible?: boolean;
+  titleBarModifiedDateVisible?: boolean;
+  titleBarFilenameVisible?: boolean;
   sidebarWidthPx?: number;
   defaultNoteName?: string;
   interfaceZoom?: number;

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -20,6 +20,7 @@ export interface ThemeSettings {
 export type FontFamily = "system-sans" | "serif" | "monospace";
 export type TextDirection = "auto" | "ltr" | "rtl";
 export type EditorWidth = "narrow" | "normal" | "wide" | "full" | "custom";
+export type NoteSortOrder = "newest" | "oldest";
 
 export interface EditorFontSettings {
   baseFontFamily?: FontFamily;
@@ -49,6 +50,7 @@ export interface Settings {
   editorFont?: EditorFontSettings;
   gitEnabled?: boolean;
   foldersEnabled?: boolean;
+  sidebarSortOrder?: NoteSortOrder;
   pinnedNoteIds?: string[];
   textDirection?: TextDirection;
   editorWidth?: EditorWidth;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
## Summary

- Add a setting to enable or disable mouse-based editor page-width resizing.
- Add a setting to show or hide the fixed formatting toolbar.
- Add mutually exclusive title-bar information modes: modification date, filename, or none.
- Preserve donor defaults for existing settings files.
- Reset all new appearance preferences with the existing appearance reset action.

## Stack

This is PR 2 of the Scratch 1.0.1 backport stack and depends on #198.

The branch currently includes the PR 1 commit. Merge #198 first; this PR diff will then shrink to the editor display and title-bar settings commit.

## Verification

- `npm test -- --run`: 9 files, 29 tests passed.
- `npm run build`: passed.
- `cargo test --manifest-path src-tauri/Cargo.toml --quiet`: 2 tests passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`: passed.
- `git diff --check HEAD^..HEAD`: passed.

Tests cover donor defaults and migration behavior, disabled resize pointer behavior, formatting-toolbar visibility, accessible settings controls, title-bar mode exclusivity, filename formatting, and empty-state handling.

## Scope

Standalone Markdown windows, Settings access from standalone windows, multiple workspaces, selection formatting, tables, and drag/drop remain outside this change.

No zero-bug guarantee is possible. Risk is reduced through focused regression tests, the complete frontend suite available at this stack level, production build, Rust serialization tests, Clippy, and a scope-leak audit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added sidebar sorting by newest or oldest, with the selection saved between sessions.
  * Added a collapsible Folders section with persisted state.
  * Added editor settings for toolbar visibility and adjustable editor-width resizing.
  * Added title-bar options to show the filename, modified date, or neither.
* **Bug Fixes**
  * Improved editor-width measurement for more accurate resizing behavior.
* **Tests**
  * Expanded coverage for settings, sorting, folder behavior, title-bar information, and editor controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->