### PR TITLE
feat: improve code block creation UX

### DIFF
--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -109,6 +109,60 @@ import {
   FolderPlusIcon,
 } from "../icons";
 
+const ScratchCodeBlock = CodeBlockLowlight.extend({
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockView);
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      ...this.parent?.(),
+      "Mod-Alt-c": () => {
+        if (this.editor.isActive(this.name)) {
+          return this.editor.commands.toggleCodeBlock();
+        }
+
+        const { selection } = this.editor.state;
+        if (selection.empty && selection.$from.parentOffset > 0) {
+          return this.editor
+            .chain()
+            .splitBlock({ keepMarks: false })
+            .setCodeBlock()
+            .run();
+        }
+
+        return this.editor.commands.setCodeBlock();
+      },
+    };
+  },
+
+  addInputRules() {
+    return [
+      new InputRule({
+        // Convert after the first space following ``` or ```language.
+        // Unlike TipTap's default rule, this also works after text.
+        find: /```([a-zA-Z0-9_+#.-]*) $/,
+        handler: ({ state, range, match, chain }) => {
+          const command = chain().deleteRange(range);
+
+          if (state.doc.resolve(range.from).parentOffset > 0) {
+            command
+              .setTextSelection(range.from)
+              .splitBlock({ keepMarks: false });
+          }
+
+          command
+            .setCodeBlock(
+              match[1] ? { language: match[1].toLowerCase() } : undefined,
+            )
+            .run();
+        },
+      }),
+      ...(this.parent?.() ?? []),
+    ];
+  },
+});
+
 function formatDateTime(timestamp: number): string {
   const date = new Date(timestamp * 1000);
   return date.toLocaleDateString(undefined, {
@@ -1054,11 +1108,7 @@ export function Editor({
         },
         codeBlock: false,
       }),
-      CodeBlockLowlight.extend({
-        addNodeView() {
-          return ReactNodeViewRenderer(CodeBlockView);
-        },
-      }).configure({
+      ScratchCodeBlock.configure({
         lowlight,
         defaultLanguage: null,
       }),

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -109,6 +109,24 @@ import {
   FolderPlusIcon,
 } from "../icons";
 
+function toggleCodeBlockAtCursor(editor: TiptapEditor): boolean {
+  if (editor.isActive("codeBlock")) {
+    return editor.chain().focus().toggleCodeBlock().run();
+  }
+
+  const { selection } = editor.state;
+  if (selection.empty && selection.$from.parentOffset > 0) {
+    return editor
+      .chain()
+      .focus()
+      .splitBlock({ keepMarks: false })
+      .setCodeBlock()
+      .run();
+  }
+
+  return editor.chain().focus().setCodeBlock().run();
+}
+
 const ScratchCodeBlock = CodeBlockLowlight.extend({
   addNodeView() {
     return ReactNodeViewRenderer(CodeBlockView);
@@ -117,22 +135,7 @@ const ScratchCodeBlock = CodeBlockLowlight.extend({
   addKeyboardShortcuts() {
     return {
       ...this.parent?.(),
-      "Mod-Alt-c": () => {
-        if (this.editor.isActive(this.name)) {
-          return this.editor.commands.toggleCodeBlock();
-        }
-
-        const { selection } = this.editor.state;
-        if (selection.empty && selection.$from.parentOffset > 0) {
-          return this.editor
-            .chain()
-            .splitBlock({ keepMarks: false })
-            .setCodeBlock()
-            .run();
-        }
-
-        return this.editor.commands.setCodeBlock();
-      },
+      "Mod-Alt-c": () => toggleCodeBlockAtCursor(this.editor),
     };
   },
 
@@ -407,7 +410,7 @@ function FormatBar({
         <InlineCodeIcon className="w-4.5 h-4.5 stroke-[1.5]" />
       </ToolbarButton>
       <ToolbarButton
-        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+        onClick={() => toggleCodeBlockAtCursor(editor)}
         isActive={editor.isActive("codeBlock")}
         title={`Code Block (${mod}${isMac ? "" : "+"}${alt}${isMac ? "" : "+"}C)`}
       >

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -133,9 +133,50 @@ const ScratchCodeBlock = CodeBlockLowlight.extend({
   },
 
   addKeyboardShortcuts() {
+    const parentShortcuts = this.parent?.() ?? {};
+
     return {
-      ...this.parent?.(),
+      ...parentShortcuts,
       "Mod-Alt-c": () => toggleCodeBlockAtCursor(this.editor),
+      Enter: (props) => {
+        const { selection } = this.editor.state;
+        const { $from } = selection;
+
+        if (
+          selection.empty &&
+          !this.editor.isActive(this.name) &&
+          !this.editor.isActive("code")
+        ) {
+          const textBeforeCursor = $from.parent.textBetween(
+            0,
+            $from.parentOffset,
+          );
+          const match = textBeforeCursor.match(
+            /```([a-zA-Z0-9_+#.-]*)$/,
+          );
+
+          if (match) {
+            const triggerFrom = selection.from - match[0].length;
+            const command = this.editor
+              .chain()
+              .deleteRange({ from: triggerFrom, to: selection.from });
+
+            if ($from.parentOffset > match[0].length) {
+              command
+                .setTextSelection(triggerFrom)
+                .splitBlock({ keepMarks: false });
+            }
+
+            return command
+              .setCodeBlock(
+                match[1] ? { language: match[1].toLowerCase() } : undefined,
+              )
+              .run();
+          }
+        }
+
+        return parentShortcuts.Enter?.(props) ?? false;
+      },
     };
   },
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/46c8f55c-b1ee-4a16-9bcb-73023ae9ff88


The first video shows the current behavior.

Previously, fenced code block syntax had to be entered at the beginning of an empty line. This made it difficult to use code blocks naturally within ordered Markdown lists.

## New behavior


https://github.com/user-attachments/assets/2f7779a0-2e60-4388-acf1-a01218dd66d4


Typing three backticks with an optional language identifier, followed by Space, still creates a code block with the specified language.

The syntax can now also be entered in the middle of existing text. For example, where `|` represents the cursor:

````text
AAA ```cpp| BBB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added improved code-block formatting from the editor toolbar or `Mod-Alt-c` keyboard shortcut.
  - Code blocks can be created without overwriting existing content, with text automatically split when needed.
  - Fenced code syntax is converted into formatted code blocks when activated or completed.
- **Improvements**
  - Existing code blocks are preserved during formatting.
  - Code languages are normalized for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->