### PR TITLE
feat: add spell check and auto correct settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,10 @@ pub struct Settings {
     pub pinned_note_ids: Option<Vec<String>>,
     #[serde(rename = "textDirection")]
     pub text_direction: Option<TextDirection>,
+    #[serde(rename = "spellCheckEnabled")]
+    pub spell_check_enabled: Option<bool>,
+    #[serde(rename = "autoCorrectEnabled")]
+    pub auto_correct_enabled: Option<bool>,
     #[serde(rename = "editorWidth")]
     pub editor_width: Option<String>,
     #[serde(rename = "defaultNoteName")]

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -546,7 +546,7 @@ export function Editor({
   const pinNote = notesCtx?.pinNote;
   const unpinNote = notesCtx?.unpinNote;
   const notes = notesCtx?.notes;
-  const { textDirection } = useTheme();
+  const { textDirection, spellCheckEnabled, autoCorrectEnabled } = useTheme();
   const [isSaving, setIsSaving] = useState(false);
   // Force re-render when selection changes to update toolbar active states
   const [, setSelectionKey] = useState(0);
@@ -1134,8 +1134,8 @@ export function Editor({
       attributes: {
         class:
           "prose prose-lg dark:prose-invert max-w-3xl mx-auto focus:outline-none min-h-full px-6 pt-8 pb-24",
-        spellcheck: "true",
-        autocorrect: "on",
+        spellcheck: spellCheckEnabled ? "true" : "false",
+        autocorrect: autoCorrectEnabled ? "on" : "off",
         autocapitalize: "sentences",
       },
       // Serialize copied text as markdown instead of plain text

--- a/src/components/settings/EditorSettingsSection.tsx
+++ b/src/components/settings/EditorSettingsSection.tsx
@@ -66,6 +66,10 @@ export function AppearanceSettingsSection() {
     resetEditorFontSettings,
     textDirection,
     setTextDirection,
+    spellCheckEnabled,
+    setSpellCheckEnabled,
+    autoCorrectEnabled,
+    setAutoCorrectEnabled,
     editorWidth,
     setEditorWidth,
     interfaceZoom,
@@ -174,6 +178,64 @@ export function AppearanceSettingsSection() {
             className="mt-4"
           />
         )}
+      </section>
+
+      {/* Divider */}
+      <div className="border-t border-border border-dashed" />
+
+      {/* Writing Section */}
+      <section>
+        <h2 className="text-xl font-medium mb-3">Writing</h2>
+        <div className="rounded-[10px] border border-border pl-4 py-3 pr-3 space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="text-sm text-text font-medium">
+              Spell Check
+            </label>
+            <div className="flex gap-1 p-1 rounded-[10px] border border-border shrink-0">
+              <Button
+                onClick={() => setSpellCheckEnabled(false)}
+                variant={!spellCheckEnabled ? "primary" : "ghost"}
+                size="xs"
+              >
+                Off
+              </Button>
+              <Button
+                onClick={() => setSpellCheckEnabled(true)}
+                variant={spellCheckEnabled ? "primary" : "ghost"}
+                size="xs"
+              >
+                On
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="text-sm text-text font-medium">
+              Auto Correct
+            </label>
+            <div className="flex gap-1 p-1 rounded-[10px] border border-border shrink-0">
+              <Button
+                onClick={() => setAutoCorrectEnabled(false)}
+                variant={!autoCorrectEnabled ? "primary" : "ghost"}
+                size="xs"
+              >
+                Off
+              </Button>
+              <Button
+                onClick={() => setAutoCorrectEnabled(true)}
+                variant={autoCorrectEnabled ? "primary" : "ghost"}
+                size="xs"
+              >
+                On
+              </Button>
+            </div>
+          </div>
+        </div>
+        <p className="mt-3 text-sm text-text-muted">
+          Auto Correct requires Spell Check. Enabling it also enables Spell
+          Check. Spell checking may reduce performance when inserting large
+          amounts of text.
+        </p>
       </section>
 
       {/* Divider */}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -106,6 +106,10 @@ interface ThemeContextType {
   reloadSettings: () => Promise<void>;
   textDirection: TextDirection;
   setTextDirection: (dir: TextDirection) => void;
+  spellCheckEnabled: boolean;
+  setSpellCheckEnabled: (enabled: boolean) => void;
+  autoCorrectEnabled: boolean;
+  setAutoCorrectEnabled: (enabled: boolean) => void;
   editorWidth: EditorWidth;
   setEditorWidth: (width: EditorWidth) => void;
   interfaceZoom: number;
@@ -186,6 +190,8 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     Required<EditorFontSettings>
   >(defaultEditorFontSettings);
   const [textDirection, setTextDirectionState] = useState<TextDirection>("auto");
+  const [spellCheckEnabled, setSpellCheckEnabledState] = useState(false);
+  const [autoCorrectEnabled, setAutoCorrectEnabledState] = useState(false);
   const [editorWidth, setEditorWidthState] = useState<EditorWidth>("normal");
   const [interfaceZoom, setInterfaceZoomState] = useState(1.0);
   const [customEditorWidthPx, setCustomEditorWidthPxState] = useState<number>(
@@ -225,6 +231,11 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
       if (isTextDirection(settings.textDirection)) {
         setTextDirectionState(settings.textDirection);
       }
+      const isSpellCheckEnabled = settings.spellCheckEnabled === true;
+      setSpellCheckEnabledState(isSpellCheckEnabled);
+      setAutoCorrectEnabledState(
+        isSpellCheckEnabled && settings.autoCorrectEnabled === true,
+      );
       if (
         settings.editorWidth === "narrow" ||
         settings.editorWidth === "normal" ||
@@ -431,6 +442,40 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     }
   }, []);
 
+  const setSpellCheckEnabled = useCallback(async (enabled: boolean) => {
+    setSpellCheckEnabledState(enabled);
+    if (!enabled) {
+      setAutoCorrectEnabledState(false);
+    }
+    try {
+      const settings = await getSettings();
+      await updateSettings({
+        ...settings,
+        spellCheckEnabled: enabled,
+        autoCorrectEnabled: enabled && autoCorrectEnabled,
+      });
+    } catch (error) {
+      console.error("Failed to save spell check setting:", error);
+    }
+  }, [autoCorrectEnabled]);
+
+  const setAutoCorrectEnabled = useCallback(async (enabled: boolean) => {
+    setAutoCorrectEnabledState(enabled);
+    if (enabled) {
+      setSpellCheckEnabledState(true);
+    }
+    try {
+      const settings = await getSettings();
+      await updateSettings({
+        ...settings,
+        spellCheckEnabled: enabled || spellCheckEnabled,
+        autoCorrectEnabled: enabled,
+      });
+    } catch (error) {
+      console.error("Failed to save auto correct setting:", error);
+    }
+  }, [spellCheckEnabled]);
+
   // Save and set editor width
   const setEditorWidth = useCallback(async (width: EditorWidth) => {
     setEditorWidthState(width);
@@ -620,6 +665,10 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
         reloadSettings,
         textDirection,
         setTextDirection,
+        spellCheckEnabled,
+        setSpellCheckEnabled,
+        autoCorrectEnabled,
+        setAutoCorrectEnabled,
         editorWidth,
         setEditorWidth,
         interfaceZoom,

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -51,6 +51,8 @@ export interface Settings {
   foldersEnabled?: boolean;
   pinnedNoteIds?: string[];
   textDirection?: TextDirection;
+  spellCheckEnabled?: boolean;
+  autoCorrectEnabled?: boolean;
   editorWidth?: EditorWidth;
   customEditorWidthPx?: number;
   sidebarWidthPx?: number;


### PR DESCRIPTION
Adds separate Spell Check and Auto Correct options under Settings → Appearance.
Both default to off to avoid WebKit lag when pasting large amounts of text.

https://github.com/user-attachments/assets/fe084e35-e69c-47a7-afd9-aec6e58489ab



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Writing settings for enabling or disabling spell check and auto-correct.
  * Settings are saved and applied dynamically in the editor.
  * Auto-correct automatically enables spell check; disabling spell check disables auto-correct.
  * Added guidance about performance considerations for large text insertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->