### PR TITLE
feat: add configurable sidebar note sorting to settings

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -131,6 +131,8 @@ pub struct Settings {
     pub folders_enabled: Option<bool>,
     #[serde(rename = "ignoredPatterns")]
     pub ignored_patterns: Option<Vec<String>>,
+    #[serde(rename = "sortOrder")]
+    pub sort_order: Option<String>,
     #[serde(rename = "customColorsLight")]
     pub custom_colors_light: Option<std::collections::HashMap<String, String>>,
     #[serde(rename = "customColorsDark")]

--- a/src/components/notes/FolderTreeView.tsx
+++ b/src/components/notes/FolderTreeView.tsx
@@ -484,7 +484,7 @@ interface FolderTreeViewProps {
 
 export function FolderTreeView({
   pinnedIds,
-  settings: _settings,
+  settings,
   multiSelectedNoteIds,
   setMultiSelectedNoteIds,
   lastClickedNoteId,
@@ -535,8 +535,8 @@ export function FolderTreeView({
   }, [collapsedFolders]);
 
   const tree = useMemo(
-    () => buildFolderTree(notes, pinnedIds, knownFolders),
-    [notes, pinnedIds, knownFolders],
+    () => buildFolderTree(notes, pinnedIds, knownFolders, settings?.sortOrder),
+    [notes, pinnedIds, knownFolders, settings?.sortOrder],
   );
 
   const handleToggleCollapse = useCallback((path: string) => {

--- a/src/components/notes/NoteList.tsx
+++ b/src/components/notes/NoteList.tsx
@@ -22,6 +22,7 @@ import {
   TrashIcon,
 } from "../icons";
 import type { Settings } from "../../types/note";
+import { getSortStrategy } from "../../lib/sorting";
 
 const menuItemClass =
   "px-3 py-1.5 text-sm text-text cursor-pointer outline-none hover:bg-bg-muted focus:bg-bg-muted flex items-center gap-2 rounded-sm";
@@ -304,8 +305,16 @@ export function NoteList({
         modified: r.modified,
       }));
     }
-    return notes;
-  }, [searchQuery, searchResults, notes]);
+    const strategy = getSortStrategy(settings?.sortOrder);
+    const sorted = [...notes];
+    sorted.sort((a, b) => {
+      const ap = pinnedIds.has(a.id);
+      const bp = pinnedIds.has(b.id);
+      if (ap !== bp) return ap ? -1 : 1;
+      return strategy.compareNotes(a, b);
+    });
+    return sorted;
+  }, [searchQuery, searchResults, notes, settings?.sortOrder, pinnedIds]);
 
   // Listen for focus request from editor (when Escape is pressed)
   useEffect(() => {

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -16,6 +16,7 @@ import {
   XIcon,
 } from "../icons";
 import type { Settings } from "../../types/note";
+import { SORT_STRATEGIES, DEFAULT_SORT_ORDER } from "../../lib/sorting";
 
 // Format remote URL for display - extract user/repo from full URL
 function formatRemoteUrl(url: string | null): string {
@@ -300,6 +301,22 @@ export function GeneralSettingsSection() {
             </p>
           </div>
           <FoldersToggle />
+        </div>
+      </section>
+
+      {/* Divider */}
+      <div className="border-t border-border border-dashed" />
+
+      {/* Note Sorting Section */}
+      <section className="pb-2">
+        <div className="flex items-center justify-between gap-6">
+          <div className="flex flex-col gap-0.75">
+            <h2 className="text-xl font-medium">Sidebar Note Order</h2>
+            <p className="text-sm text-text-muted max-w-lg">
+              Choose how notes and folder contents are ordered in the sidebar.
+            </p>
+          </div>
+          <NoteSortSelector />
         </div>
       </section>
 
@@ -812,6 +829,54 @@ function FoldersToggle() {
         On
       </Button>
     </div>
+  );
+}
+
+function NoteSortSelector() {
+  const [sortOrder, setSortOrder] = useState<string>(DEFAULT_SORT_ORDER);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { notesFolder, refreshNotes } = useNotes();
+
+  useEffect(() => {
+    invoke<Settings>("get_settings")
+      .then((settings) => {
+        setSortOrder(settings.sortOrder || DEFAULT_SORT_ORDER);
+      })
+      .catch((err) => {
+        console.error("Failed to load sortOrder:", err);
+      });
+  }, [notesFolder]);
+
+  const handleChange = async (newOrder: string) => {
+    setIsUpdating(true);
+    try {
+      const settings = await invoke<Settings>("get_settings");
+      await invoke("update_settings", {
+        newSettings: { ...settings, sortOrder: newOrder },
+      });
+      setSortOrder(newOrder);
+      refreshNotes();
+      toast.success("Sidebar sorting updated");
+    } catch {
+      toast.error("Failed to update sidebar sorting");
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <select
+      value={sortOrder}
+      onChange={(e) => handleChange(e.target.value)}
+      disabled={isUpdating}
+      className="px-3 py-1.5 text-sm bg-bg border border-border rounded-[10px] text-text cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent shrink-0"
+    >
+      {Object.values(SORT_STRATEGIES).map((strategy) => (
+        <option key={strategy.id} value={strategy.id}>
+          {strategy.label}
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/src/components/settings/GeneralSettingsSection.tsx
+++ b/src/components/settings/GeneralSettingsSection.tsx
@@ -15,7 +15,7 @@ import {
   ChevronRightIcon,
   XIcon,
 } from "../icons";
-import type { Settings } from "../../types/note";
+import type { Settings, SortOrder } from "../../types/note";
 import { SORT_STRATEGIES, DEFAULT_SORT_ORDER } from "../../lib/sorting";
 
 // Format remote URL for display - extract user/repo from full URL
@@ -833,7 +833,7 @@ function FoldersToggle() {
 }
 
 function NoteSortSelector() {
-  const [sortOrder, setSortOrder] = useState<string>(DEFAULT_SORT_ORDER);
+  const [sortOrder, setSortOrder] = useState<SortOrder>(DEFAULT_SORT_ORDER);
   const [isUpdating, setIsUpdating] = useState(false);
   const { notesFolder, refreshNotes } = useNotes();
 
@@ -847,7 +847,7 @@ function NoteSortSelector() {
       });
   }, [notesFolder]);
 
-  const handleChange = async (newOrder: string) => {
+  const handleChange = async (newOrder: SortOrder) => {
     setIsUpdating(true);
     try {
       const settings = await invoke<Settings>("get_settings");
@@ -867,7 +867,7 @@ function NoteSortSelector() {
   return (
     <select
       value={sortOrder}
-      onChange={(e) => handleChange(e.target.value)}
+      onChange={(e) => handleChange(e.target.value as SortOrder)}
       disabled={isUpdating}
       className="px-3 py-1.5 text-sm bg-bg border border-border rounded-[10px] text-text cursor-pointer focus:outline-none focus:ring-1 focus:ring-accent shrink-0"
     >

--- a/src/lib/folderTree.ts
+++ b/src/lib/folderTree.ts
@@ -1,4 +1,5 @@
 import type { NoteMetadata, FolderNode } from "../types/note";
+import { getSortStrategy } from "./sorting";
 
 export interface FolderTreeData {
   rootNotes: NoteMetadata[];
@@ -9,7 +10,9 @@ export function buildFolderTree(
   notes: NoteMetadata[],
   pinnedIds: Set<string>,
   knownFolders?: string[],
+  sortOrder?: string,
 ): FolderTreeData {
+  const strategy = getSortStrategy(sortOrder);
   const rootNotes: NoteMetadata[] = [];
   const folderMap = new Map<string, FolderNode>();
 
@@ -51,13 +54,16 @@ export function buildFolderTree(
     }
   }
 
+  const folderComparator =
+    strategy.compareFolders || ((a: FolderNode, b: FolderNode) => a.name.localeCompare(b.name));
+
   function sortNode(node: FolderNode) {
-    node.children.sort((a, b) => a.name.localeCompare(b.name));
+    node.children.sort(folderComparator);
     node.notes.sort((a, b) => {
       const ap = pinnedIds.has(a.id);
       const bp = pinnedIds.has(b.id);
       if (ap !== bp) return ap ? -1 : 1;
-      return b.modified - a.modified;
+      return strategy.compareNotes(a, b);
     });
     node.children.forEach(sortNode);
   }
@@ -65,15 +71,15 @@ export function buildFolderTree(
   const topLevelFolders = Array.from(folderMap.values()).filter(
     (f) => !f.path.includes("/"),
   );
-  topLevelFolders.sort((a, b) => a.name.localeCompare(b.name));
+  topLevelFolders.sort(folderComparator);
   topLevelFolders.forEach(sortNode);
 
-  // Sort root notes: pinned first, then by modified desc
+  // Sort root notes: pinned first, then by strategy
   rootNotes.sort((a, b) => {
     const ap = pinnedIds.has(a.id);
     const bp = pinnedIds.has(b.id);
     if (ap !== bp) return ap ? -1 : 1;
-    return b.modified - a.modified;
+    return strategy.compareNotes(a, b);
   });
 
   return { rootNotes, folders: topLevelFolders };

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -1,7 +1,7 @@
-import type { NoteMetadata, FolderNode } from "../types/note";
+import type { NoteMetadata, FolderNode, SortOrder } from "../types/note";
 
 export interface SortStrategy {
-  id: string;
+  id: SortOrder;
   label: string;
   description: string;
   compareNotes: (a: NoteMetadata, b: NoteMetadata) => number;
@@ -9,10 +9,14 @@ export interface SortStrategy {
 }
 
 // Natural collation for human-friendly sorting (e.g. "1 - Note", "2 - Note", "10 - Note")
+const naturalCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
 const naturalCompare = (a: string, b: string) =>
-  a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+  naturalCollator.compare(a, b) || a.localeCompare(b);
 
-export const SORT_STRATEGIES: Record<string, SortStrategy> = {
+export const SORT_STRATEGIES: Record<SortOrder, SortStrategy> = {
   "title-asc": {
     id: "title-asc",
     label: "Alphabetical / Folder Structure (A–Z)",
@@ -43,11 +47,11 @@ export const SORT_STRATEGIES: Record<string, SortStrategy> = {
   },
 };
 
-export const DEFAULT_SORT_ORDER = "title-asc";
+export const DEFAULT_SORT_ORDER: SortOrder = "modified-desc";
 
-export function getSortStrategy(sortOrder?: string): SortStrategy {
-  if (sortOrder && SORT_STRATEGIES[sortOrder]) {
-    return SORT_STRATEGIES[sortOrder];
+export function getSortStrategy(sortOrder?: string | null): SortStrategy {
+  if (sortOrder && (sortOrder as SortOrder) in SORT_STRATEGIES) {
+    return SORT_STRATEGIES[sortOrder as SortOrder];
   }
   return SORT_STRATEGIES[DEFAULT_SORT_ORDER];
 }

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -1,0 +1,53 @@
+import type { NoteMetadata, FolderNode } from "../types/note";
+
+export interface SortStrategy {
+  id: string;
+  label: string;
+  description: string;
+  compareNotes: (a: NoteMetadata, b: NoteMetadata) => number;
+  compareFolders?: (a: FolderNode, b: FolderNode) => number;
+}
+
+// Natural collation for human-friendly sorting (e.g. "1 - Note", "2 - Note", "10 - Note")
+const naturalCompare = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" });
+
+export const SORT_STRATEGIES: Record<string, SortStrategy> = {
+  "title-asc": {
+    id: "title-asc",
+    label: "Alphabetical / Folder Structure (A–Z)",
+    description: "Sorted by note title and natural number order",
+    compareNotes: (a, b) => naturalCompare(a.title || a.id, b.title || b.id),
+    compareFolders: (a, b) => naturalCompare(a.name, b.name),
+  },
+  "modified-desc": {
+    id: "modified-desc",
+    label: "Last Modified (Newest First)",
+    description: "Recently edited notes appear at the top",
+    compareNotes: (a, b) => b.modified - a.modified,
+    compareFolders: (a, b) => naturalCompare(a.name, b.name),
+  },
+  "modified-asc": {
+    id: "modified-asc",
+    label: "Last Modified (Oldest First)",
+    description: "Oldest edited notes appear at the top",
+    compareNotes: (a, b) => a.modified - b.modified,
+    compareFolders: (a, b) => naturalCompare(a.name, b.name),
+  },
+  "title-desc": {
+    id: "title-desc",
+    label: "Alphabetical (Z–A)",
+    description: "Reverse alphabetical order",
+    compareNotes: (a, b) => naturalCompare(b.title || b.id, a.title || a.id),
+    compareFolders: (a, b) => naturalCompare(b.name, a.name),
+  },
+};
+
+export const DEFAULT_SORT_ORDER = "title-asc";
+
+export function getSortStrategy(sortOrder?: string): SortStrategy {
+  if (sortOrder && SORT_STRATEGIES[sortOrder]) {
+    return SORT_STRATEGIES[sortOrder];
+  }
+  return SORT_STRATEGIES[DEFAULT_SORT_ORDER];
+}

--- a/src/lib/sorting.ts
+++ b/src/lib/sorting.ts
@@ -50,7 +50,7 @@ export const SORT_STRATEGIES: Record<SortOrder, SortStrategy> = {
 export const DEFAULT_SORT_ORDER: SortOrder = "modified-desc";
 
 export function getSortStrategy(sortOrder?: string | null): SortStrategy {
-  if (sortOrder && (sortOrder as SortOrder) in SORT_STRATEGIES) {
+  if (sortOrder && Object.hasOwn(SORT_STRATEGIES, sortOrder)) {
     return SORT_STRATEGIES[sortOrder as SortOrder];
   }
   return SORT_STRATEGIES[DEFAULT_SORT_ORDER];

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -20,6 +20,7 @@ export interface ThemeSettings {
 export type FontFamily = "system-sans" | "serif" | "monospace";
 export type TextDirection = "auto" | "ltr" | "rtl";
 export type EditorWidth = "narrow" | "normal" | "wide" | "full" | "custom";
+export type SortOrder = "title-asc" | "title-desc" | "modified-desc" | "modified-asc" | string;
 
 export interface EditorFontSettings {
   baseFontFamily?: FontFamily;
@@ -50,6 +51,7 @@ export interface Settings {
   gitEnabled?: boolean;
   foldersEnabled?: boolean;
   pinnedNoteIds?: string[];
+  sortOrder?: SortOrder;
   textDirection?: TextDirection;
   editorWidth?: EditorWidth;
   customEditorWidthPx?: number;

--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -20,7 +20,7 @@ export interface ThemeSettings {
 export type FontFamily = "system-sans" | "serif" | "monospace";
 export type TextDirection = "auto" | "ltr" | "rtl";
 export type EditorWidth = "narrow" | "normal" | "wide" | "full" | "custom";
-export type SortOrder = "title-asc" | "title-desc" | "modified-desc" | "modified-asc" | string;
+export type SortOrder = "title-asc" | "title-desc" | "modified-desc" | "modified-asc";
 
 export interface EditorFontSettings {
   baseFontFamily?: FontFamily;


### PR DESCRIPTION
### Summary
Currently, notes in the sidebar and folder tree are sorted strictly by modification time (`modified` descending). Whenever a note is edited or clicked, it auto-saves and jumps to the top of its folder, disrupting numeric or alphabetical folder layouts (e.g. `0 - ...`, `1 - ...`, `2 - ...`).

This PR adds an extensible **Sidebar Note Order** option to Settings, allowing users to choose how notes and folders are ordered.

### Changes
- **Extensible Strategy Pattern (`src/lib/sorting.ts`)**:
  - Implemented `SORT_STRATEGIES` registry with:
    - `title-asc`: Alphabetical / Folder Structure (A–Z natural number collation)
    - `modified-desc`: Last Modified (Newest First)
    - `modified-asc`: Last Modified (Oldest First)
    - `title-desc`: Alphabetical (Z–A)
  - Designed so new custom sorting methods can be plugged in easily.
- **Backend & Types (`src/types/note.ts`, `src-tauri/src/lib.rs`)**:
  - Added `sortOrder` to `Settings` interface and Rust struct for persistence in `.scratch/settings.json`.
- **Tree & Flat List (`src/lib/folderTree.ts`, `FolderTreeView.tsx`, `NoteList.tsx`)**:
  - Updated `buildFolderTree` and flat `NoteList` to sort notes and subfolders according to the active `SortStrategy` while preserving pinned notes at the top.
- **Settings UI (`GeneralSettingsSection.tsx`)**:
  - Added a "Sidebar Note Order" dropdown selector in the Folder Settings tab.

### Verification
- Tested in development mode (`npm run tauri dev`).
- Verified that choosing `Alphabetical / Folder Structure (A–Z)` keeps numeric note sequences (`0 - ...`, `1 - ...`, `2 - ...`) in their fixed positions when clicked/edited.
- Verified TypeScript compilation and bundle build (`npm run build`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable note sorting in General Settings, including title and modification-date ordering.
  * Notes and folders now respect the selected sort order.
  * Pinned notes remain prioritized in lists and folder views.
  * Added natural, case-insensitive sorting for titles and folder names.
  * Invalid or unavailable sorting preferences fall back to the default modified-date order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->